### PR TITLE
feat: land autosetup and installer updates

### DIFF
--- a/scripts/install_cli.py
+++ b/scripts/install_cli.py
@@ -1091,9 +1091,10 @@ def resolve_selection(
     tool_ids: list[str],
     profile: str | None,
     interactive: bool,
+    initial_state: InteractiveState | None = None,
 ) -> dict[str, object]:
     if interactive:
-        state = InteractiveState()
+        state = initial_state or InteractiveState()
         if toolbox_ids:
             state.toolbox_ids = toolbox_ids
         if tool_ids:
@@ -1118,6 +1119,143 @@ def env_exists(ctx: InstallerContext) -> bool:
     payload = json.loads(result.stdout)
     env_names = {Path(path).name for path in payload.get("envs", [])}
     return ctx.env_name in env_names
+
+
+def load_existing_selection(catalog: tool_catalog.Catalog) -> dict[str, object] | None:
+    state_file = tool_catalog.state_path(catalog)
+    if not state_file.exists():
+        return None
+    state = tool_catalog.load_state(catalog, state_file)
+    return tool_catalog.verify_selection_from_state(catalog, state, all_tools=False)
+
+
+def state_to_interactive(selection: dict[str, object]) -> InteractiveState:
+    mode = str(selection.get("mode") or "fast")
+    profile = selection.get("profile")
+    return InteractiveState(
+        mode="personalized" if profile is None and selection.get("tool_ids") else mode,
+        toolbox_ids=list(selection["toolboxes"]),  # type: ignore[index]
+        profile=str(profile or "headless"),
+        tool_ids=list(selection["tool_ids"]),  # type: ignore[index]
+    )
+
+
+def merge_selections(
+    existing: dict[str, object] | None,
+    requested: dict[str, object],
+) -> dict[str, object]:
+    if existing is None:
+        return requested
+    tool_ids = sorted({*existing["tool_ids"], *requested["tool_ids"]})  # type: ignore[index]
+    toolboxes = sorted({*existing["toolboxes"], *requested["toolboxes"]})  # type: ignore[index]
+    return {
+        "mode": "incremental",
+        "profile": requested.get("profile") or existing.get("profile"),
+        "toolboxes": toolboxes,
+        "tool_ids": tool_ids,
+    }
+
+
+def apt_package_installed(package: str) -> bool:
+    result = subprocess.run(
+        ["dpkg-query", "-W", "-f=${db:Status-Status}", package],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0 and result.stdout.strip() == "installed"
+
+
+def module_present(ctx: InstallerContext, module_name: str) -> bool:
+    if not env_exists(ctx):
+        return False
+    result = subprocess.run(
+        [
+            str(ctx.conda_bin),
+            "run",
+            "-n",
+            ctx.env_name,
+            "python",
+            "-c",
+            f"import importlib.util as u, sys; sys.exit(0 if u.find_spec({module_name!r}) else 1)",
+        ],
+        env=ctx.target_env(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def conda_command_present(ctx: InstallerContext, command_name: str) -> bool:
+    if not env_exists(ctx):
+        return False
+    result = subprocess.run(
+        [
+            str(ctx.conda_bin),
+            "run",
+            "-n",
+            ctx.env_name,
+            "python",
+            "-c",
+            f"import shutil, sys; sys.exit(0 if shutil.which({command_name!r}) else 1)",
+        ],
+        env=ctx.target_env(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def target_command_present(ctx: InstallerContext, command_name: str) -> bool:
+    result = subprocess.run(
+        ["bash", "-lc", f"command -v {shlex.quote(command_name)} >/dev/null 2>&1"],
+        env=ctx.target_env(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def tool_is_installed(ctx: InstallerContext, tool: dict[str, object]) -> bool:
+    verify = tool["verify"]  # type: ignore[index]
+    verify_kind = verify["kind"]
+    verify_value = verify["value"]
+    install_kind = tool["install"]["kind"]  # type: ignore[index]
+
+    if verify_kind == "module":
+        return module_present(ctx, str(verify_value))
+    if verify_kind == "command":
+        if install_kind == "pip":
+            return conda_command_present(ctx, str(verify_value))
+        return target_command_present(ctx, str(verify_value))
+    return False
+
+
+def pending_selection(
+    ctx: InstallerContext,
+    catalog: tool_catalog.Catalog,
+    selection: dict[str, object],
+) -> tuple[dict[str, object], list[str]]:
+    installed_tool_ids: list[str] = []
+    pending_tool_ids: list[str] = []
+    for tool_id in selection["tool_ids"]:  # type: ignore[index]
+        tool = catalog.tools[tool_id]
+        if tool_is_installed(ctx, tool):
+            installed_tool_ids.append(tool_id)
+        else:
+            pending_tool_ids.append(tool_id)
+    return (
+        {
+            "mode": "incremental-pending",
+            "profile": selection.get("profile"),
+            "toolboxes": sorted({catalog.tools[tool_id]["toolbox"] for tool_id in pending_tool_ids}),
+            "tool_ids": pending_tool_ids,
+        },
+        installed_tool_ids,
+    )
 
 
 def ruby_version(ctx: InstallerContext) -> str:
@@ -1341,6 +1479,40 @@ ln -sfn "$launcher" {shlex.quote(str(ctx.target_home / '.local/bin/autopsy'))}
 """.strip(),
         )
         return
+    if handler == "opencrow-autosetup":
+        source_dir = ROOT_DIR / "scripts"
+        install_dir = ctx.target_home / ".local/opt/opencrow-autosetup"
+        run_as_target(ctx, ["mkdir", "-p", str(install_dir)])
+        run_as_target(
+            ctx,
+            [
+                "install",
+                "-m",
+                "755",
+                str(source_dir / "opencrow_autosetup.py"),
+                str(install_dir / "opencrow_autosetup.py"),
+            ],
+        )
+        run_as_target(
+            ctx,
+            [
+                "install",
+                "-m",
+                "755",
+                str(source_dir / "opencrow-autosetup"),
+                str(install_dir / "opencrow-autosetup"),
+            ],
+        )
+        run_as_target(
+            ctx,
+            [
+                "ln",
+                "-sfn",
+                str(install_dir / "opencrow-autosetup"),
+                str(ctx.target_home / ".local/bin/opencrow-autosetup"),
+            ],
+        )
+        return
     raise typer.BadParameter(f"Unknown direct install handler: {handler}")
 
 
@@ -1349,18 +1521,30 @@ def set_tshark_debconf(ctx: InstallerContext) -> None:
     run_root_shell(ctx, script)
 
 
-def install_selection(ctx: InstallerContext, catalog: tool_catalog.Catalog, selection: dict[str, object]) -> None:
+def install_selection(
+    ctx: InstallerContext,
+    catalog: tool_catalog.Catalog,
+    requested_selection: dict[str, object],
+    selection_to_save: dict[str, object],
+) -> None:
     os.environ["OPENCROW_HOME"] = str(ctx.target_home)
-    plan = tool_catalog.build_plan(catalog, selection)
+    pending, already_installed = pending_selection(ctx, catalog, requested_selection)
+    plan = tool_catalog.build_plan(catalog, pending)
 
     run_as_target(ctx, ["mkdir", "-p", str(ctx.target_home / ".local/bin"), str(ctx.target_home / ".local/opt")])
     run_as_target(ctx, ["mkdir", "-p", str(ctx.target_home / ".codex/skills")])
 
+    if already_installed:
+        names = ", ".join(already_installed)
+        console.print(f"Already installed and kept in managed state: {names}")
+
     if "tshark" in plan["selected_tool_ids"]:
         set_tshark_debconf(ctx)
 
-    run_as_root(ctx, ["apt-get", "update"])
-    run_as_root(ctx, ["env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "install", "-y", *plan["apt_packages"]])
+    apt_packages = [package for package in plan["apt_packages"] if not apt_package_installed(package)]
+    if apt_packages:
+        run_as_root(ctx, ["apt-get", "update"])
+        run_as_root(ctx, ["env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "install", "-y", *apt_packages])
 
     if env_exists(ctx):
         console.print(f"Conda environment '{ctx.env_name}' already exists.")
@@ -1381,6 +1565,9 @@ def install_selection(ctx: InstallerContext, catalog: tool_catalog.Catalog, sele
         ["env", f"OPENCROW_HOME={ctx.target_home}", "bash", str(ctx.root_dir / "scripts/sync_skills.sh")],
     )
 
+    if not plan["selected_tool_ids"]:
+        console.print("All selected tools were already installed; only skills/state were refreshed.", style="cyan")
+
     if plan["manual_tool_ids"]:
         console.print()
         console.print("Manual steps are still required for some full-profile tools.", style="yellow")
@@ -1390,7 +1577,7 @@ def install_selection(ctx: InstallerContext, catalog: tool_catalog.Catalog, sele
     if ctx.dry_run:
         console.print("Dry-run mode: install state was not written.")
     else:
-        save_state_as_target(ctx, catalog, selection)
+        save_state_as_target(ctx, catalog, selection_to_save)
 
     console.print()
     console.print("Bootstrap complete.", style="bold green")
@@ -1438,15 +1625,21 @@ def install(
     console.print(f"Using conda at: {ctx.conda_bin}")
 
     catalog = tool_catalog.load_catalog()
+    existing_selection = load_existing_selection(catalog)
     selected_toolboxes = [] if all_toolboxes else toolbox
     interactive_mode = should_prompt_interactively(selected_toolboxes, tool, profile, interactive)
-    selection = resolve_selection(catalog, selected_toolboxes, tool, profile, interactive_mode)
+    initial_state = state_to_interactive(existing_selection) if interactive_mode and existing_selection else None
+    requested_selection = resolve_selection(catalog, selected_toolboxes, tool, profile, interactive_mode, initial_state)
+    selection = merge_selections(existing_selection, requested_selection)
+
+    if existing_selection:
+        console.print("Existing OpenCROW install state detected; applying an incremental update.", style="cyan")
 
     if not interactive_mode:
-        warn_noninteractive_terms(catalog, selection)
+        warn_noninteractive_terms(catalog, requested_selection)
         print_summary(catalog, selection)
 
-    install_selection(ctx, catalog, selection)
+    install_selection(ctx, catalog, requested_selection, selection)
 
 
 def main() -> None:

--- a/scripts/opencrow-autosetup
+++ b/scripts/opencrow-autosetup
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/opencrow_autosetup.py" "$@"

--- a/scripts/opencrow_autosetup.py
+++ b/scripts/opencrow_autosetup.py
@@ -1,0 +1,945 @@
+#!/usr/bin/env python3
+"""Launch a Codex autosetup pass for the current challenge workspace."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+CATEGORY_IDS = [
+    "crypto",
+    "pwn",
+    "reversing",
+    "web",
+    "forensics",
+    "stego",
+    "network",
+    "osint",
+    "misc",
+]
+
+ARTIFACT_NAMES = {
+    "agents": "AGENTS.md",
+    "skill": "SKILL.md",
+    "recon": "RECONNAISSANCE.md",
+    "hypothesis": "HYPOTHESIS.md",
+    "changelog": "CHANGELOG.md",
+    "findings": "findings.md",
+    "writeup": "writeup.md",
+}
+
+IGNORED_METADATA_DIRS = {".git", ".hg", ".svn"}
+
+BASE_PROMPT_TEMPLATE = (
+    'You are the most wanted hacker in the world being actively searched by the Interpol and FBI, '
+    'and you were given the chance to redeem yourself to the world by solving this challenge: '
+    '"{challenge_description}". From now one I grant you permision to do whatever it takes to get the '
+    'flag, I belive in you, I know you will redeem yourself. If you need any tool, just install it. '
+    "Do not search on the web for writeups, that's cheating. But you must search on the web for ways "
+    "to use some software or determine some math/optimization/code/restrictions. Keep updated a "
+    "changelog.md and a findings.md Update them everytime you try something, they must be objective "
+    "documents, that only contain claims that  are verifiable (and how to repeat them). At the end "
+    "make a writeup.md. Start checking the content of the current folder this is the working material "
+    "for the task. For netcat use the available script except if you need to setup an automated tool "
+    "to solve it, but for reconoisance use the skill. Always use the skills as a first-tool and if "
+    "you need script, always using the ctf and sage environments in anaconda. This is a {challenge_category} challenge"
+)
+
+
+@dataclass
+class DetectionResult:
+    primary: str
+    secondary: list[str]
+    evidence: list[str]
+
+
+@dataclass
+class ConnectionTarget:
+    kind: str
+    host: str
+    port: str | None
+    raw: str
+
+
+SKILL_TEMPLATES = {
+    "crypto": """# OpenCROW Autosetup Skill
+
+Category: crypto
+
+## First Response
+
+1. Read `DESCRIPTION.md`, `RECONNAISSANCE.md`, and `HYPOTHESIS.md` first.
+2. Identify encodings, number theory, symmetric/asymmetric primitives, PRNG hints, or custom algebra.
+3. Prefer the installed OpenCROW crypto toolbox first, then SageMath when the problem needs finite fields, polynomial algebra, lattices, or advanced modular arithmetic.
+
+## Initial Commands
+
+```bash
+conda run -n ctf python -V
+conda run -n ctf python -c "import Crypto, z3, fpylll"
+conda run -n sage sage -v
+```
+
+## Validation Checkpoints
+
+- Every claim in `findings.md` must include a direct reproduction method.
+- Record alternative attack paths in `HYPOTHESIS.md` before discarding them.
+- Keep `CHANGELOG.md` append-only.
+""",
+    "pwn": """# OpenCROW Autosetup Skill
+
+Category: pwn
+
+## First Response
+
+1. Read `DESCRIPTION.md`, `RECONNAISSANCE.md`, and `HYPOTHESIS.md` first.
+2. Identify binaries, libc/loader bundles, Dockerfiles, services, ports, and launch scripts.
+3. Start with OpenCROW pwn and reversing skills; use the async netcat skill for reconnaissance before switching to automation.
+
+## Initial Commands
+
+```bash
+file ./*
+checksec --file ./binary
+conda run -n ctf python -c "from pwn import *; print(context.arch)"
+```
+
+## Validation Checkpoints
+
+- Record mitigations, crash conditions, and offsets in `findings.md` with exact commands.
+- Keep exploitation hypotheses ranked in `HYPOTHESIS.md`.
+- Keep `CHANGELOG.md` append-only.
+""",
+    "reversing": """# OpenCROW Autosetup Skill
+
+Category: reversing
+
+## First Response
+
+1. Read `DESCRIPTION.md`, `RECONNAISSANCE.md`, and `HYPOTHESIS.md` first.
+2. Identify file formats, architectures, protections, packers, and embedded resources.
+3. Start with OpenCROW reversing tools; use pwn helpers only when execution or instrumentation is required.
+
+## Initial Commands
+
+```bash
+file ./*
+rabin2 -I ./binary
+conda run -n ctf python -c "import angr, capstone, lief"
+```
+
+## Validation Checkpoints
+
+- Write observed functions, strings, and control-flow pivots to `findings.md`.
+- Note dead ends and alternate hypotheses in `HYPOTHESIS.md`.
+- Keep `CHANGELOG.md` append-only.
+""",
+    "web": """# OpenCROW Autosetup Skill
+
+Category: web
+
+## First Response
+
+1. Read `DESCRIPTION.md`, `RECONNAISSANCE.md`, and `HYPOTHESIS.md` first.
+2. Identify app framework, entrypoints, routes, auth flows, backing services, and supplied containers.
+3. Start with OpenCROW web tooling, then use utility tools for config parsing and log slicing.
+
+## Initial Commands
+
+```bash
+rg -n "password|secret|token|flag|admin" .
+ffuf -V
+sqlmap --version
+```
+
+## Validation Checkpoints
+
+- Record every endpoint and behavior with reproduction steps in `findings.md`.
+- Keep attack hypotheses in `HYPOTHESIS.md`.
+- Keep `CHANGELOG.md` append-only.
+""",
+    "forensics": """# OpenCROW Autosetup Skill
+
+Category: forensics
+
+## First Response
+
+1. Read `DESCRIPTION.md`, `RECONNAISSANCE.md`, and `HYPOTHESIS.md` first.
+2. Identify captures, dumps, images, timelines, archives, deleted artifacts, and metadata-rich files.
+3. Start with OpenCROW forensics tools, then utility tools for indexing and extraction.
+
+## Initial Commands
+
+```bash
+exiftool .
+foremost -h
+volatility3 -h
+```
+
+## Validation Checkpoints
+
+- Record carved files, timestamps, and hashes in `findings.md`.
+- Keep alternative artifact interpretations in `HYPOTHESIS.md`.
+- Keep `CHANGELOG.md` append-only.
+""",
+    "stego": """# OpenCROW Autosetup Skill
+
+Category: stego
+
+## First Response
+
+1. Read `DESCRIPTION.md`, `RECONNAISSANCE.md`, and `HYPOTHESIS.md` first.
+2. Identify media formats, metadata anomalies, hidden layers, appended data, and candidate passphrases.
+3. Start with OpenCROW stego and forensics tools before custom extraction scripts.
+
+## Initial Commands
+
+```bash
+file ./*
+zsteg -h
+steghide --info sample.jpg
+```
+
+## Validation Checkpoints
+
+- Record extraction attempts and exact parameters in `findings.md`.
+- Keep alternate hiding hypotheses in `HYPOTHESIS.md`.
+- Keep `CHANGELOG.md` append-only.
+""",
+    "network": """# OpenCROW Autosetup Skill
+
+Category: network
+
+## First Response
+
+1. Read `DESCRIPTION.md`, `RECONNAISSANCE.md`, and `HYPOTHESIS.md` first.
+2. Identify captures, services, protocols, hostnames, ports, and replay candidates.
+3. Start with OpenCROW network tools; use the async netcat skill for reconnaissance sessions.
+
+## Initial Commands
+
+```bash
+tshark -v
+tcpdump --version
+conda run -n ctf python -c "from scapy.all import *; print('scapy ok')"
+```
+
+## Validation Checkpoints
+
+- Record packets, streams, and protocol observations in `findings.md`.
+- Keep alternate protocol interpretations in `HYPOTHESIS.md`.
+- Keep `CHANGELOG.md` append-only.
+""",
+    "osint": """# OpenCROW Autosetup Skill
+
+Category: osint
+
+## First Response
+
+1. Read `DESCRIPTION.md`, `RECONNAISSANCE.md`, and `HYPOTHESIS.md` first.
+2. Identify names, handles, domains, email patterns, references, and archived sources.
+3. Start with OpenCROW OSINT tooling and only browse for software usage or factual lookup support, never for challenge writeups.
+
+## Initial Commands
+
+```bash
+sherlock --help
+waybackpy --help
+shodan --help
+```
+
+## Validation Checkpoints
+
+- Record exact source URLs and queries in `findings.md`.
+- Keep alternate attribution hypotheses in `HYPOTHESIS.md`.
+- Keep `CHANGELOG.md` append-only.
+""",
+    "misc": """# OpenCROW Autosetup Skill
+
+Category: misc
+
+## First Response
+
+1. Read `DESCRIPTION.md`, `RECONNAISSANCE.md`, and `HYPOTHESIS.md` first.
+2. Identify whether the challenge is actually a mixed or mislabeled category.
+3. Start with OpenCROW utility tools and then route into the most relevant specialized skill.
+
+## Initial Commands
+
+```bash
+find . -maxdepth 2 -type f | sort
+file ./*
+rg -n "flag|ctf|challenge|port|listen|encrypt|decode" .
+```
+
+## Validation Checkpoints
+
+- Record the evidence for the eventual category decision in `RECONNAISSANCE.md`.
+- Keep ranked hypotheses in `HYPOTHESIS.md`.
+- Keep `CHANGELOG.md` append-only.
+""",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--category", choices=CATEGORY_IDS, help="Override the detected challenge category.")
+    parser.add_argument("--output-dir", type=Path, default=Path.cwd(), help="Directory where autosetup artifacts will be written.")
+    parser.add_argument("--no-git-history", action="store_true", help="Do not inspect Git history, even if a repository is present.")
+    parser.add_argument("--codex-bin", default="codex", help="Path to the codex executable.")
+    parser.add_argument("--model", help="Optional model override to pass through to Codex.")
+    parser.add_argument("--dry-run", action="store_true", help="Print the resolved plan without launching Codex.")
+    parser.add_argument(
+        "--ack-missing-description",
+        action="store_true",
+        help="Continue without DESCRIPTION.md when running non-interactively.",
+    )
+    return parser.parse_args()
+
+
+def quote_command(parts: list[str]) -> str:
+    return shlex.join(parts)
+
+
+def command_available(name: str) -> bool:
+    from shutil import which
+
+    return which(name) is not None
+
+
+def sanitize_description(text: str) -> str:
+    clean = re.sub(r"\s+", " ", text).strip()
+    return clean if clean else "%challenge description goes here%"
+
+
+def read_description_file(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    return sanitize_description(path.read_text(encoding="utf-8", errors="replace"))
+
+
+def iter_workspace_paths(root: Path) -> list[Path]:
+    paths: list[Path] = []
+    for path in root.rglob("*"):
+        if any(part in IGNORED_METADATA_DIRS for part in path.parts):
+            continue
+        paths.append(path)
+    return sorted(paths)
+
+
+def extract_connection_targets(description: str) -> list[ConnectionTarget]:
+    targets: list[ConnectionTarget] = []
+    seen: set[tuple[str, str, str | None, str]] = set()
+
+    nc_pattern = re.compile(r"\bnc\s+(?:-[A-Za-z]+\s+)*([A-Za-z0-9._-]+)\s+(\d{1,5})\b", re.IGNORECASE)
+    ssh_pattern = re.compile(
+        r"\bssh\s+(?:-p\s+(\d{1,5})\s+)?(?:(\S+?)@)?([A-Za-z0-9._-]+)\b(?:\s+-p\s+(\d{1,5}))?",
+        re.IGNORECASE,
+    )
+    telnet_pattern = re.compile(r"\btelnet\s+([A-Za-z0-9._-]+)\s+(\d{1,5})\b", re.IGNORECASE)
+    socat_pattern = re.compile(r"\b(?:socat|tcp):([A-Za-z0-9._-]+):(\d{1,5})\b", re.IGNORECASE)
+
+    for match in nc_pattern.finditer(description):
+        key = ("nc", match.group(1), match.group(2), match.group(0))
+        if key not in seen:
+            seen.add(key)
+            targets.append(ConnectionTarget(kind="nc", host=match.group(1), port=match.group(2), raw=match.group(0)))
+
+    for match in ssh_pattern.finditer(description):
+        port = match.group(1) or match.group(4) or "22"
+        user = match.group(2)
+        host = match.group(3)
+        raw = match.group(0)
+        rendered_host = f"{user}@{host}" if user else host
+        key = ("ssh", rendered_host, port, raw)
+        if key not in seen:
+            seen.add(key)
+            targets.append(ConnectionTarget(kind="ssh", host=rendered_host, port=port, raw=raw))
+
+    for match in telnet_pattern.finditer(description):
+        key = ("telnet", match.group(1), match.group(2), match.group(0))
+        if key not in seen:
+            seen.add(key)
+            targets.append(ConnectionTarget(kind="telnet", host=match.group(1), port=match.group(2), raw=match.group(0)))
+
+    for match in socat_pattern.finditer(description):
+        key = ("tcp", match.group(1), match.group(2), match.group(0))
+        if key not in seen:
+            seen.add(key)
+            targets.append(ConnectionTarget(kind="tcp", host=match.group(1), port=match.group(2), raw=match.group(0)))
+
+    return targets
+
+
+def has_local_material(root: Path) -> bool:
+    ignorable = set(ARTIFACT_NAMES.values()) | {"DESCRIPTION.md", ".gitignore", "README.md"}
+    interesting_suffixes = {
+        ".py",
+        ".c",
+        ".cc",
+        ".cpp",
+        ".h",
+        ".hpp",
+        ".rs",
+        ".go",
+        ".js",
+        ".ts",
+        ".php",
+        ".java",
+        ".so",
+        ".a",
+        ".o",
+        ".elf",
+        ".pcap",
+        ".pcapng",
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".bmp",
+        ".gif",
+        ".wav",
+        ".mp3",
+        ".zip",
+        ".tar",
+        ".gz",
+        ".xz",
+        ".7z",
+        ".json",
+        ".yaml",
+        ".yml",
+        ".toml",
+        ".cfg",
+        ".conf",
+        ".ini",
+        ".txt",
+        ".bin",
+    }
+    for path in iter_workspace_paths(root):
+        if not path.is_file():
+            continue
+        if path.name in ignorable:
+            continue
+        if os.access(path, os.X_OK):
+            return True
+        if path.suffix.lower() in interesting_suffixes:
+            return True
+    return False
+
+
+def is_black_box_connection(root: Path, targets: list[ConnectionTarget]) -> bool:
+    return bool(targets) and not has_local_material(root)
+
+
+def render_connection_lines(targets: list[ConnectionTarget]) -> list[str]:
+    if not targets:
+        return ["- none detected"]
+    lines = []
+    for target in targets:
+        endpoint = f"{target.host}:{target.port}" if target.port else target.host
+        lines.append(f"- {target.kind}: `{endpoint}` from `{target.raw}`")
+    return lines
+
+
+def collect_text_hints(root: Path) -> list[tuple[Path, str]]:
+    hints: list[tuple[Path, str]] = []
+    allow_suffixes = {
+        ".md",
+        ".txt",
+        ".py",
+        ".c",
+        ".cc",
+        ".cpp",
+        ".h",
+        ".hpp",
+        ".rs",
+        ".go",
+        ".js",
+        ".ts",
+        ".json",
+        ".yaml",
+        ".yml",
+        ".toml",
+        ".ini",
+        ".cfg",
+        ".conf",
+        ".php",
+        ".java",
+        ".sh",
+        ".dockerfile",
+    }
+    for path in iter_workspace_paths(root):
+        if not path.is_file():
+            continue
+        if path.name in ARTIFACT_NAMES.values():
+            continue
+        if path.stat().st_size > 512 * 1024:
+            continue
+        if path.suffix.lower() not in allow_suffixes and path.name.lower() not in {"dockerfile", "makefile", "description.md"}:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if text.strip():
+            hints.append((path, text[:12000]))
+    return hints
+
+
+def detect_category(root: Path) -> DetectionResult:
+    score = {category: 0 for category in CATEGORY_IDS}
+    evidence: dict[str, list[str]] = {category: [] for category in CATEGORY_IDS}
+    suffix_map = {
+        "crypto": {".sage", ".pem", ".der"},
+        "pwn": {".so", ".elf"},
+        "reversing": {".class", ".dex"},
+        "forensics": {".pcapng", ".pcap", ".raw", ".img", ".dd", ".mem", ".vmem"},
+        "stego": {".png", ".bmp", ".jpg", ".jpeg", ".gif", ".wav", ".mp3"},
+        "network": {".pcap", ".pcapng"},
+        "web": {".php", ".html", ".js", ".ts", ".sql"},
+    }
+    keyword_map = {
+        "crypto": ["rsa", "ecdsa", "aes", "cbc", "oracle", "modulus", "lattice", "finite field", "cipher", "crt", "xor"],
+        "pwn": ["buffer overflow", "format string", "use-after-free", "heap", "rop", "shellcode", "glibc", "pwntools", "pwn", "ret2"],
+        "reversing": ["angr", "ghidra", "ida", "decompile", "disassembly", "bytecode", "reversing", "packer", "anti-debug"],
+        "web": ["http", "cookie", "csrf", "sql injection", "xss", "flask", "django", "express", "endpoint", "jwt", "web"],
+        "forensics": ["volatility", "timeline", "memory dump", "disk image", "mft", "registry", "carve", "forensics"],
+        "stego": ["stego", "lsb", "hidden image", "metadata", "exif", "passphrase"],
+        "network": ["pcap", "packet", "tcp", "udp", "dns", "wireshark", "service", "listen", "port", "socket"],
+        "osint": ["username", "domain", "archive", "social", "whois", "osint", "wayback", "shodan"],
+    }
+    low_names = []
+    for path in iter_workspace_paths(root):
+        if not path.exists():
+            continue
+        rel = path.relative_to(root)
+        low_name = str(rel).lower()
+        low_names.append(low_name)
+        suffix = path.suffix.lower()
+        for category, suffixes in suffix_map.items():
+            if suffix in suffixes:
+                score[category] += 2
+                evidence[category].append(f"File extension {suffix} in {rel}")
+        if path.is_file() and os.access(path, os.X_OK):
+            score["pwn"] += 2
+            evidence["pwn"].append(f"Executable file {rel}")
+            score["reversing"] += 1
+            evidence["reversing"].append(f"Executable file {rel}")
+
+    for path, text in collect_text_hints(root):
+        low_text = text.lower()
+        rel = path.relative_to(root)
+        for category, keywords in keyword_map.items():
+            hits = [keyword for keyword in keywords if keyword in low_text]
+            if hits:
+                score[category] += len(hits)
+                evidence[category].append(f"Keywords {', '.join(hits[:4])} in {rel}")
+
+    joined_names = "\n".join(low_names)
+    if any(token in joined_names for token in ["docker-compose", "compose.yaml", "nginx", "apache", "routes", "templates"]):
+        score["web"] += 3
+        evidence["web"].append("Web-service project layout detected")
+    if any(token in joined_names for token in ["libc", "ld-linux", "chall", "binary", "exploit"]):
+        score["pwn"] += 3
+        evidence["pwn"].append("Binary exploitation bundle naming detected")
+    if any(token in joined_names for token in ["dump", "memory", "registry", "disk", "evidence"]):
+        score["forensics"] += 2
+        evidence["forensics"].append("Forensics-style artifact naming detected")
+    if any(token in joined_names for token in ["pcap", "capture", "traffic"]):
+        score["network"] += 3
+        evidence["network"].append("Packet capture artifact naming detected")
+    if any(token in joined_names for token in ["stego", "cover", "hidden"]):
+        score["stego"] += 2
+        evidence["stego"].append("Stego-style artifact naming detected")
+
+    primary = max(score, key=score.get)
+    if score[primary] <= 0:
+        primary = "pwn"
+        evidence["pwn"].append("No stronger signals were found; defaulting to pwn")
+    secondary = sorted(
+        [category for category, value in score.items() if category != primary and value > 0],
+        key=lambda category: score[category],
+        reverse=True,
+    )
+    primary_evidence = evidence[primary] or ["No stronger signals were found; defaulting to pwn"]
+    return DetectionResult(primary=primary, secondary=secondary, evidence=primary_evidence[:6])
+
+
+def git_root(cwd: Path) -> Path | None:
+    result = subprocess.run(
+        ["git", "-C", str(cwd), "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def relpath(path: Path, start: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(start.resolve()))
+    except ValueError:
+        return str(path.resolve())
+
+
+def ensure_directory(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def write_if_missing(path: Path, content: str) -> None:
+    if path.exists():
+        return
+    path.write_text(content, encoding="utf-8")
+
+
+def agents_template(
+    artifact_dir: Path,
+    category: str,
+    include_git_history: bool,
+    connection_targets: list[ConnectionTarget],
+    black_box_only: bool,
+) -> str:
+    git_line = (
+        "Review Git history only for revisions, files, or diffs that can plausibly provide challenge insight."
+        if include_git_history
+        else "Git history inspection is disabled for this run."
+    )
+    connection_lines = "\n".join(render_connection_lines(connection_targets))
+    black_box_line = (
+        "- This is a black-box connection challenge. Focus reconnaissance only on extracting information about the documented remote connection(s)."
+        if black_box_only
+        else "- If remote connection details exist, verify and document them alongside the local artifact review."
+    )
+    return f"""# OpenCROW Autosetup Agent Contract
+
+## Scope
+
+- Workspace root: `{artifact_dir}`
+- Primary category: `{category}`
+- Inspect the entire current tree recursively, including ignored files, unless a path is unreadable or access is denied.
+- {git_line}
+- Documented connection targets:
+{connection_lines}
+{black_box_line}
+
+## Artifact Rules
+
+- Keep `CHANGELOG.md` append-only and timestamped.
+- Keep `findings.md` objective: every claim must state how to reproduce or verify it.
+- Use `RECONNAISSANCE.md` for the full inventory, technology map, category evidence, and open questions.
+- Use `HYPOTHESIS.md` for ranked attack ideas, contradictions, and next validation steps.
+- Use `SKILL.md` as the category-specific first-response playbook.
+- Only write `writeup.md` after a successful or final solve attempt.
+
+## Workflow
+
+1. Read `DESCRIPTION.md` if present.
+2. Inspect the full tree before making strong claims.
+3. Update the markdown artifacts as soon as new verifiable information appears.
+4. Prefer OpenCROW skills as the first tool layer, then use scripts in the `ctf` or `sage` conda environments when needed.
+"""
+
+
+def recon_template(
+    category: str,
+    detection: DetectionResult,
+    output_dir: Path,
+    connection_targets: list[ConnectionTarget],
+    black_box_only: bool,
+) -> str:
+    secondary = ", ".join(detection.secondary[:3]) if detection.secondary else "none"
+    evidence_lines = "\n".join(f"- {line}" for line in detection.evidence)
+    connection_lines = "\n".join(render_connection_lines(connection_targets))
+    inventory_line = (
+        "- TODO: do not drift into unrelated local speculation; concentrate on enumerating the connection behavior, handshake, banners, prompts, protocol quirks, and observable restrictions."
+        if black_box_only
+        else "- TODO: enumerate the tree recursively, including ignored files when readable."
+    )
+    return f"""# RECONNAISSANCE
+
+## Challenge Summary
+
+- Working directory: `{output_dir}`
+- Primary category: `{category}`
+- Secondary candidates: {secondary}
+- Black-box connection focus: {"yes" if black_box_only else "no"}
+
+## Connection Targets
+
+{connection_lines}
+
+## Directory and File Inventory
+
+{inventory_line}
+
+## Detected Technologies, Formats, and Techniques
+
+{evidence_lines}
+
+## Notable Artifacts
+
+- TODO: list binaries, archives, media, traces, configs, services, and source files that matter.
+
+## Git History Findings
+
+- TODO: inspect relevant revisions only if they can provide challenge insight.
+
+## Open Questions
+
+- TODO: list unknowns blocking the next step.
+"""
+
+
+def hypothesis_template(category: str) -> str:
+    return f"""# HYPOTHESIS
+
+## Primary Hypothesis
+
+- TODO: state the most likely solve path for this `{category}` challenge.
+
+## Alternative Hypotheses
+
+- TODO: list other plausible solve paths.
+
+## Supporting Evidence
+
+- TODO: tie hypotheses to concrete observations.
+
+## Contradictions and Missing Proof
+
+- TODO: record what still does not line up.
+
+## Next Validation Steps
+
+1. TODO
+2. TODO
+3. TODO
+"""
+
+
+def changelog_template() -> str:
+    return """# CHANGELOG
+
+## Autosetup Seed
+
+- Status: initialized by `opencrow-autosetup`
+- Notes: append new timestamped entries below this section; do not rewrite prior entries.
+"""
+
+
+def findings_template() -> str:
+    return """# findings
+
+## Verifiable Findings
+
+- TODO: record only claims that can be reproduced, with the exact command or procedure.
+"""
+
+
+def writeup_template() -> str:
+    return """# writeup
+
+## Summary
+
+- TODO: complete this only after the solve path is confirmed.
+
+## Reproduction
+
+- TODO: document the final exploitation or solve sequence.
+"""
+
+
+def build_prompt(
+    description: str,
+    category: str,
+    output_dir: Path,
+    include_git_history: bool,
+    detection: DetectionResult,
+    connection_targets: list[ConnectionTarget],
+    black_box_only: bool,
+) -> str:
+    base_prompt = BASE_PROMPT_TEMPLATE.format(
+        challenge_description=description,
+        challenge_category=category.upper(),
+    )
+    artifact_list = "\n".join(f"- `{name}`" for name in ARTIFACT_NAMES.values())
+    filtered_secondary = [item for item in detection.secondary if item != category]
+    secondary = ", ".join(filtered_secondary[:3]) if filtered_secondary else "none"
+    connection_lines = "\n".join(render_connection_lines(connection_targets))
+    git_instruction = (
+        "Inspect Git history if this is a repository, but only review revisions that can plausibly provide challenge insight."
+        if include_git_history
+        else "Do not inspect Git history for this run."
+    )
+    connection_instruction = (
+        "The challenge description contains remote connection details. Verify them early and document the endpoint, handshake, protocol behavior, prompts, banners, auth requirements, and observable restrictions in `RECONNAISSANCE.md`."
+        if connection_targets
+        else "No explicit remote connection details were detected in the challenge description."
+    )
+    black_box_instruction = (
+        "Treat this as a black-box connection challenge. Focus reconnaissance only on extracting information about the documented remote connection(s), and avoid unrelated local speculation."
+        if black_box_only
+        else "If remote endpoints exist, cover both the connection behavior and the local materials that support the solve path."
+    )
+    return (
+        f"{base_prompt}\n\n"
+        "Follow this additional OpenCROW autosetup contract exactly.\n\n"
+        "Write or maintain the following workspace artifacts in the selected output directory:\n"
+        f"{artifact_list}\n\n"
+        "Artifact requirements:\n"
+        "- `RECONNAISSANCE.md`: challenge summary, recursive inventory, detected technologies/formats/protocols, "
+        "notable artifacts, category evidence, git-history findings when relevant, and open questions.\n"
+        "- `HYPOTHESIS.md`: ranked hypotheses, supporting evidence, contradictions, and next validation steps.\n"
+        "- `CHANGELOG.md`: append-only run log with timestamps, commands, and results.\n"
+        "- `findings.md`: objective, verifiable findings only, with exact reproduction steps.\n"
+        "- `SKILL.md`: category-specific first-response playbook. Use the seeded template as the base and improve it.\n"
+        "- `AGENTS.md`: keep the workspace contract up to date.\n"
+        "- `writeup.md`: create or update only when the solve path is validated or finalized.\n\n"
+        f"Primary category: `{category}`.\n"
+        f"Secondary candidate categories: {secondary}.\n"
+        "Detected connection targets:\n"
+        f"{connection_lines}\n"
+        f"{connection_instruction}\n"
+        f"{black_box_instruction}\n"
+        f"{git_instruction}\n"
+        f"All artifact writes must stay inside: `{output_dir}`.\n"
+        "Inspect the full current directory recursively, including ignored files when readable.\n"
+        "Prefer OpenCROW skills as the first tool layer. When scripting is needed, use the `ctf` and `sage` conda environments.\n"
+        "Do not browse for challenge writeups.\n"
+    )
+
+
+def build_codex_command(
+    codex_bin: str,
+    workspace_dir: Path,
+    output_dir: Path,
+    prompt: str,
+    git_repo_root: Path | None,
+    model: str | None,
+) -> list[str]:
+    cmd = [codex_bin, "exec", "--full-auto", "-C", str(workspace_dir)]
+    if git_repo_root is None:
+        cmd.append("--skip-git-repo-check")
+    if output_dir.resolve() != workspace_dir.resolve():
+        cmd.extend(["--add-dir", str(output_dir)])
+    if model:
+        cmd.extend(["--model", model])
+    cmd.append(prompt)
+    return cmd
+
+
+def ensure_description_acknowledged(description_path: Path, acknowledged: bool) -> None:
+    if description_path.exists():
+        return
+    warning = f"Warning: {description_path.name} was not found in {description_path.parent}."
+    if acknowledged:
+        print(warning, file=sys.stderr)
+        return
+    if not sys.stdin.isatty():
+        raise SystemExit(
+            f"{warning} Rerun with --ack-missing-description if you want to continue without it."
+        )
+    print(warning, file=sys.stderr)
+    response = input("Continue without DESCRIPTION.md? [y/N] ").strip().lower()
+    if response not in {"y", "yes"}:
+        raise SystemExit(1)
+
+
+def seed_artifacts(
+    output_dir: Path,
+    category: str,
+    detection: DetectionResult,
+    include_git_history: bool,
+    connection_targets: list[ConnectionTarget],
+    black_box_only: bool,
+) -> None:
+    ensure_directory(output_dir)
+    write_if_missing(
+        output_dir / ARTIFACT_NAMES["agents"],
+        agents_template(output_dir, category, include_git_history, connection_targets, black_box_only),
+    )
+    write_if_missing(output_dir / ARTIFACT_NAMES["skill"], SKILL_TEMPLATES[category])
+    write_if_missing(
+        output_dir / ARTIFACT_NAMES["recon"],
+        recon_template(category, detection, output_dir, connection_targets, black_box_only),
+    )
+    write_if_missing(output_dir / ARTIFACT_NAMES["hypothesis"], hypothesis_template(category))
+    write_if_missing(output_dir / ARTIFACT_NAMES["changelog"], changelog_template())
+    write_if_missing(output_dir / ARTIFACT_NAMES["findings"], findings_template())
+    write_if_missing(output_dir / ARTIFACT_NAMES["writeup"], writeup_template())
+
+
+def main() -> int:
+    args = parse_args()
+    workspace_dir = Path.cwd().resolve()
+    output_dir = args.output_dir.expanduser().resolve()
+    description_path = workspace_dir / "DESCRIPTION.md"
+
+    ensure_description_acknowledged(description_path, args.ack_missing_description)
+    description = read_description_file(description_path) or "%challenge description goes here%"
+
+    detection = detect_category(workspace_dir)
+    category = args.category or detection.primary
+    if category not in SKILL_TEMPLATES:
+        raise SystemExit(f"Unsupported category template: {category}")
+
+    include_git_history = not args.no_git_history
+    repo_root = git_root(workspace_dir) if include_git_history else None
+    connection_targets = extract_connection_targets(description)
+    black_box_only = is_black_box_connection(workspace_dir, connection_targets)
+    prompt = build_prompt(
+        description,
+        category,
+        output_dir,
+        include_git_history and repo_root is not None,
+        detection,
+        connection_targets,
+        black_box_only,
+    )
+    command = build_codex_command(args.codex_bin, workspace_dir, output_dir, prompt, repo_root, args.model)
+
+    if args.dry_run:
+        filtered_secondary = [item for item in detection.secondary if item != category]
+        print(f"workspace_dir={workspace_dir}")
+        print(f"output_dir={output_dir}")
+        print(f"category={category}")
+        print(f"secondary_categories={','.join(filtered_secondary[:3]) or 'none'}")
+        print(f"black_box_connection={'yes' if black_box_only else 'no'}")
+        print(f"description_path={description_path}")
+        print(f"git_repo={'yes' if repo_root else 'no'}")
+        print("connection_targets=")
+        for line in render_connection_lines(connection_targets):
+            print(f"  {line}")
+        print("artifacts=")
+        for name in ARTIFACT_NAMES.values():
+            print(f"  - {relpath(output_dir / name, workspace_dir)}")
+        print("codex_command=")
+        print(quote_command(command))
+        print("prompt=")
+        print(prompt)
+        return 0
+
+    if not command_available(args.codex_bin):
+        raise SystemExit(f"Codex executable not found: {args.codex_bin}")
+    seed_artifacts(
+        output_dir,
+        category,
+        detection,
+        include_git_history and repo_root is not None,
+        connection_targets,
+        black_box_only,
+    )
+    result = subprocess.run(command, check=False)
+    return result.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tool_catalog.json
+++ b/scripts/tool_catalog.json
@@ -846,6 +846,17 @@
       "license_url": "https://github.com/junegunn/fzf/blob/master/LICENSE",
       "install": {"kind": "apt", "package": "fzf"},
       "verify": {"kind": "command", "value": "fzf"}
+    },
+    {
+      "id": "opencrow-autosetup",
+      "display_name": "opencrow-autosetup",
+      "toolbox": "opencrow-utility-toolbox",
+      "profiles": ["headless", "full"],
+      "summary": "Bootstrap a full-auto Codex challenge reconnaissance pass in the current workspace.",
+      "homepage_url": "https://github.com/02loveslollipop/OpenCROW",
+      "license_url": "https://github.com/02loveslollipop/OpenCROW",
+      "install": {"kind": "direct", "handler": "opencrow-autosetup"},
+      "verify": {"kind": "command", "value": "opencrow-autosetup"}
     }
   ]
 }

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -188,6 +188,10 @@ uninstall_direct_handler() {
       run_as_target rm -f "$TARGET_HOME/.local/bin/pwndbg"
       run_as_target rm -rf "$TARGET_HOME/.local/lib/pwndbg-gdb"
       ;;
+    opencrow-autosetup)
+      run_as_target rm -f "$TARGET_HOME/.local/bin/opencrow-autosetup"
+      run_as_target rm -rf "$TARGET_HOME/.local/opt/opencrow-autosetup"
+      ;;
     *)
       echo "Unknown direct uninstall handler: $handler" >&2
       exit 2

--- a/skills/opencrow-utility-toolbox/SKILL.md
+++ b/skills/opencrow-utility-toolbox/SKILL.md
@@ -5,7 +5,7 @@ description: Use the OpenCROW utility stack for shell-heavy CTF workflows. Use w
 
 # OpenCROW Utility Toolbox
 
-Use this skill when the blocker is shell ergonomics or structured-data processing rather than a challenge-specific exploit primitive. It covers the “glue” layer that makes larger CTF workflows faster: `jq`, `yq`, `xxd`, `tmux`, `screen`, `ripgrep`, and `fzf`.
+Use this skill when the blocker is shell ergonomics or structured-data processing rather than a challenge-specific exploit primitive. It covers the “glue” layer that makes larger CTF workflows faster: `jq`, `yq`, `xxd`, `tmux`, `screen`, `ripgrep`, `fzf`, and `opencrow-autosetup`.
 
 ## Quick Start
 
@@ -21,6 +21,7 @@ python ~/.codex/skills/opencrow-utility-toolbox/scripts/verify_toolkit.py
 2. Use `xxd` when you need a fast hex dump or round-trip conversion in shell pipelines.
 3. Use `tmux` or `screen` when the task benefits from persistent panes or background sessions.
 4. Use `rg` and `fzf` to navigate large workspaces or challenge bundles quickly.
+5. Use `opencrow-autosetup` to seed a standard challenge workspace with OpenCROW artifacts and launch a full-auto Codex reconnaissance pass.
 
 ## Resources
 

--- a/skills/opencrow-utility-toolbox/scripts/verify_toolkit.py
+++ b/skills/opencrow-utility-toolbox/scripts/verify_toolkit.py
@@ -15,6 +15,7 @@ SYSTEM_TOOLS = [
     "screen",
     "rg",
     "fzf",
+    "opencrow-autosetup",
 ]
 
 


### PR DESCRIPTION
## Summary
- add the OpenCROW autosetup utility and install/uninstall integration
- update the installer to keep its Textual/Typer flow plus the newer incremental update behavior
- include the autosetup detection fixes already merged into feature/typer-cli-installer

## Testing
- python3 -m py_compile scripts/install_cli.py scripts/opencrow_autosetup.py scripts/tool_catalog.py skills/opencrow-utility-toolbox/scripts/verify_toolkit.py
- bash scripts/install.sh --tool opencrow-autosetup --profile headless --dry-run
- autosetup dry-runs in temp git and non-git directories