### PR TITLE
🧹 Remove unused import Any from constellation/watcher.py

### DIFF
--- a/constellation/watcher.py
+++ b/constellation/watcher.py
@@ -10,7 +10,6 @@ import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
 
 from watchdog.events import FileSystemEvent, FileSystemEventHandler
 from watchdog.observers import Observer


### PR DESCRIPTION
🎯 **What:** Removed unused `Any` import from typing module in `constellation/watcher.py`
💡 **Why:** Fixes a static analysis warning about dead code and improves codebase maintainability.
✅ **Verification:** Verified via `python3 -m py_compile` and no build breakages. Code review rated as correct.
✨ **Result:** Cleaner namespace in `constellation/watcher.py` with no behavioral changes.

---
*PR created automatically by Jules for task [4388080176396332064](https://jules.google.com/task/4388080176396332064) started by @02loveslollipop*