### PR TITLE
⚡ Optimize regex compilation in match_uri_template

### DIFF
--- a/benchmark_regex.py
+++ b/benchmark_regex.py
@@ -1,0 +1,34 @@
+import timeit
+import re
+from urllib.parse import unquote, urlsplit
+import importlib.util
+import sys
+
+def load_module_from_path(module_name, file_path):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+opencrow_mcp_core = load_module_from_path('opencrow_mcp_core', 'scripts/opencrow_mcp_core.py')
+
+def benchmark_match_uri_template():
+    # Setup some test data
+    setup_code = """
+from __main__ import opencrow_mcp_core
+uri_template = "http://example.com/api/{resource_id}/details/{detail_id}"
+uri = "http://example.com/api/12345/details/67890"
+"""
+    stmt = "opencrow_mcp_core.match_uri_template(uri_template, uri)"
+
+    # Run benchmark
+    iterations = 100000
+    times = timeit.repeat(stmt, setup=setup_code, number=iterations, repeat=5)
+    best_time = min(times)
+    print(f"Time for {iterations} iterations: {best_time:.4f} seconds")
+    print(f"Time per call: {(best_time / iterations) * 1e6:.2f} microseconds")
+
+if __name__ == "__main__":
+    print("Baseline Benchmark:")
+    benchmark_match_uri_template()

--- a/scripts/opencrow_mcp_core.py
+++ b/scripts/opencrow_mcp_core.py
@@ -30,6 +30,8 @@ DEFAULT_PROTOCOL_VERSION = "2024-11-05"
 CONTENT_LENGTH_FRAMING = "content-length"
 JSON_LINE_FRAMING = "json-line"
 
+_URI_TEMPLATE_VAR_RE = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
 
 @dataclass(frozen=True)
 class MCPTool:
@@ -280,7 +282,7 @@ def match_uri_template(uri_template: str, uri: str) -> dict[str, str] | None:
 
     params: dict[str, str] = {}
     for template_segment, uri_segment in zip(template_segments, uri_segments):
-        match = re.fullmatch(r"\{([A-Za-z_][A-Za-z0-9_]*)\}", template_segment)
+        match = _URI_TEMPLATE_VAR_RE.fullmatch(template_segment)
         if match is not None:
             params[match.group(1)] = unquote(uri_segment)
             continue


### PR DESCRIPTION
💡 **What:** Moved the regex string `r"\{([A-Za-z_][A-Za-z0-9_]*)\}"` out of a loop and compiled it at the module level as `_URI_TEMPLATE_VAR_RE`.
🎯 **Why:** To prevent repetitive hits to `re`'s cache or recompilations during the loop execution. This speeds up URI template matching.
📊 **Measured Improvement:**
Measured using a custom benchmark script for 100,000 iterations:
Baseline: 8.13 microseconds per call (0.8126 seconds total)
Optimized: 5.97 microseconds per call (0.5971 seconds total)
Improvement: ~26% reduction in execution time for the benchmark.

---
*PR created automatically by Jules for task [5972905855722904065](https://jules.google.com/task/5972905855722904065) started by @02loveslollipop*