### PR TITLE
🧹 [code health] Remove unused `requests` import in `constellation/runtime.py`

### DIFF
--- a/constellation/runtime.py
+++ b/constellation/runtime.py
@@ -16,7 +16,6 @@ import zipfile
 from pathlib import Path, PurePosixPath
 from typing import Any
 
-import requests
 import websocket
 
 from .client import ConstellationAPIClient


### PR DESCRIPTION
🎯 **What:** Removed an unused `requests` import from `constellation/runtime.py`.
💡 **Why:** To improve code maintainability, cleanliness, and resolve static analysis warnings regarding unused imports.
✅ **Verification:** Verified the file still imports correctly and that the removal does not introduce any syntax or resolution errors. Python code continues to load successfully.
✨ **Result:** The codebase is cleaner and static analysis warning is resolved without any behavior change.

---
*PR created automatically by Jules for task [11372463106071395048](https://jules.google.com/task/11372463106071395048) started by @02loveslollipop*