### PR TITLE
🧪 Add tests for _normalize_handoff_urls

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,32 @@
+import unittest
+from constellation.backend import _normalize_handoff_urls
+
+class TestNormalizeHandoffUrls(unittest.TestCase):
+    def test_list_of_strings(self):
+        self.assertEqual(_normalize_handoff_urls(["a", "b", "c"]), ["a", "b", "c"])
+
+    def test_list_with_whitespace(self):
+        self.assertEqual(_normalize_handoff_urls([" a ", "b", " c\n"]), ["a", "b", "c"])
+
+    def test_list_with_empty_strings(self):
+        self.assertEqual(_normalize_handoff_urls(["a", "", "b", "  ", "c"]), ["a", "b", "c"])
+
+    def test_list_with_non_strings(self):
+        self.assertEqual(_normalize_handoff_urls(["a", 1, 2.5, True, "b"]), ["a", "1", "2.5", "True", "b"])
+
+    def test_string_multiline(self):
+        self.assertEqual(_normalize_handoff_urls("a\nb\nc"), ["a", "b", "c"])
+
+    def test_string_with_whitespace_and_empty_lines(self):
+        self.assertEqual(_normalize_handoff_urls(" a \n\n b \n  \n c \n"), ["a", "b", "c"])
+
+    def test_invalid_types(self):
+        self.assertEqual(_normalize_handoff_urls(None), [])
+        self.assertEqual(_normalize_handoff_urls(123), [])
+        self.assertEqual(_normalize_handoff_urls(123.45), [])
+        self.assertEqual(_normalize_handoff_urls(True), [])
+        self.assertEqual(_normalize_handoff_urls({"a": 1}), [])
+        self.assertEqual(_normalize_handoff_urls(set(["a", "b"])), [])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** Added comprehensive unit tests for the `_normalize_handoff_urls` function in `constellation/backend.py` to ensure it works correctly across various input types.

📊 **Coverage:** The tests cover the following scenarios:
- Normal lists of strings.
- Lists containing strings with trailing/leading whitespaces and empty strings.
- Lists containing non-string items (e.g. integers, floats, booleans).
- Multiline strings.
- Multiline strings with empty lines and varying whitespaces.
- Invalid input types (e.g. `None`, `int`, `float`, `bool`, `dict`, `set`) verifying they return an empty list.

✨ **Result:** Increased test coverage by providing safety nets for `_normalize_handoff_urls` function behavior against unexpected inputs or changes.

---
*PR created automatically by Jules for task [17999364399065015753](https://jules.google.com/task/17999364399065015753) started by @02loveslollipop*