### PR TITLE
🧪 [Testing Improvement] Add missing tests for web_fuzz missing URL error

### DIFF
--- a/scripts/test_opencrow_web_mcp.py
+++ b/scripts/test_opencrow_web_mcp.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from opencrow_web_mcp import web_fuzz
+
+def test_web_fuzz_missing_url_empty_dict():
+    """Test web_fuzz returns an error when target_url is not provided."""
+    arguments = {}
+    result = web_fuzz(arguments)
+    assert result.get("operation") == "web_fuzz"
+    assert result.get("summary") == "Target URL is required."
+
+def test_web_fuzz_missing_url_whitespace():
+    """Test web_fuzz returns an error when target_url is only whitespace."""
+    arguments = {"target_url": "   \n\t"}
+    result = web_fuzz(arguments)
+    assert result.get("operation") == "web_fuzz"
+    assert result.get("summary") == "Target URL is required."


### PR DESCRIPTION
🎯 **What:** Added tests to cover the missing `target_url` error condition in the `web_fuzz` function within `scripts/opencrow_web_mcp.py`.
📊 **Coverage:** The new tests in `scripts/test_opencrow_web_mcp.py` cover two scenarios: an empty dictionary where the URL is entirely omitted, and a dictionary where the `target_url` contains only whitespace characters (which gets stripped down to empty).
✨ **Result:** Increased test coverage and ensured that regressions related to `target_url` validation are caught early.

---
*PR created automatically by Jules for task [5973706683236326547](https://jules.google.com/task/5973706683236326547) started by @02loveslollipop*