### PR TITLE
🔒 Fix hardcoded default development token in constellation/config.py

### DIFF
--- a/constellation/config.py
+++ b/constellation/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import secrets
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -12,7 +13,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 CONFIG_PATH = Path.home() / ".config" / "opencrow" / "constellation" / "config.json"
 DEFAULT_STATE_DIR_NAME = ".opencrow-constellation"
-DEFAULT_DEVELOPMENT_TOKEN = "development-token-change-me"
+DEFAULT_DEVELOPMENT_TOKEN = secrets.token_hex(32)
 
 
 def _load_config_file(path: Path = CONFIG_PATH) -> dict[str, Any]:


### PR DESCRIPTION
🎯 **What:** The `DEFAULT_DEVELOPMENT_TOKEN` in `constellation/config.py` was hardcoded to a static string (`"development-token-change-me"`).
⚠️ **Risk:** If a system inadvertently falls back to this default token, it would use a known credential, allowing any attacker who knows this default string to bypass authentication and gain unauthorized access to the application or system.
🛡️ **Solution:** The hardcoded string has been replaced with a dynamically generated secure token using `secrets.token_hex(32)`. This ensures that even if a configuration token is missing and defaults are used, the resulting token is unique per process execution, fully mitigating the risk.

---
*PR created automatically by Jules for task [14199993000565702916](https://jules.google.com/task/14199993000565702916) started by @02loveslollipop*