### PR TITLE
🧪 Add test for stego_inspect missing file error

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -52,6 +52,7 @@ jobs:
           python3 -m py_compile scripts/opencrow_network_mcp.py
           python3 -m py_compile scripts/opencrow_utility_mcp.py
           python3 -m py_compile scripts/opencrow_stego_mcp.py
+          python3 scripts/test_opencrow_stego_mcp.py
           python3 -m py_compile scripts/opencrow_forensics_mcp.py
           python3 -m py_compile scripts/opencrow_osint_mcp.py
           python3 -m py_compile scripts/opencrow_web_mcp.py

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ smoke:
 	python3 -m py_compile scripts/opencrow_network_mcp.py
 	python3 -m py_compile scripts/opencrow_utility_mcp.py
 	python3 -m py_compile scripts/opencrow_stego_mcp.py
+	python3 scripts/test_opencrow_stego_mcp.py
 	python3 -m py_compile scripts/opencrow_forensics_mcp.py
 	python3 -m py_compile scripts/opencrow_osint_mcp.py
 	python3 -m py_compile scripts/opencrow_web_mcp.py

--- a/scripts/test_opencrow_stego_mcp.py
+++ b/scripts/test_opencrow_stego_mcp.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Tests for OpenCROW stego MCP server."""
+
+import sys
+import unittest
+from pathlib import Path
+
+# Add the scripts directory to the path so we can import modules from it
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from opencrow_stego_mcp import stego_inspect
+
+
+class TestStegoMCP(unittest.TestCase):
+    def test_stego_inspect_missing_file(self):
+        """Test that inspecting a nonexistent file returns the correct error envelope."""
+        arguments = {"path": "/path/to/nonexistent/file"}
+        result = stego_inspect(arguments)
+
+        self.assertEqual(result.get("operation"), "stego_inspect")
+        self.assertTrue("Input file does not exist" in result.get("summary", ""))
+        self.assertEqual(result.get("exit_code"), 2)
+        self.assertIn("stderr", result)
+        self.assertTrue("Missing file:" in result.get("stderr", ""))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** Added a missing test case for `stego_inspect` missing file error.
📊 **Coverage:** The test now checks that `stego_inspect` handles a dummy non-existent file path correctly, returning an appropriate error envelope (with `exit_code: 2`).
✨ **Result:** Improved test coverage for `opencrow_stego_mcp.py` with a simple unit test incorporated in the project's Makefile and CI.

---
*PR created automatically by Jules for task [532051652745898076](https://jules.google.com/task/532051652745898076) started by @02loveslollipop*