### PR TITLE
🧪 test: add missing test for get_member error handling

### DIFF
--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,23 @@
+import pytest
+from unittest.mock import MagicMock
+from pymongo.database import Database
+from constellation.storage import ConstellationStorage
+
+def test_get_member_invalid_id():
+    # Mock settings
+    settings = MagicMock()
+    settings.mongodb_uri = "mongodb://localhost:27017"
+
+    # Create storage without actually connecting to mongodb by mocking MongoClient
+    with pytest.MonkeyPatch.context() as m:
+        mock_client = MagicMock()
+        mock_db = MagicMock(spec=Database)
+        mock_client.__getitem__.return_value = mock_db
+        m.setattr("constellation.storage.MongoClient", MagicMock(return_value=mock_client))
+        storage = ConstellationStorage(settings)
+
+        # Test with malformed member_id
+        result = storage.get_member("invalid_id")
+
+        # Should return None instead of raising an exception
+        assert result is None


### PR DESCRIPTION
🎯 **What:** Added a missing test for `get_member` error handling in `constellation/storage.py` when passed a malformed member ID string.
📊 **Coverage:** The scenario where a malformed ID string (e.g., "invalid_id") fails to initialize a MongoDB `ObjectId` is now tested using `pytest` and `unittest.mock.MagicMock`.
✨ **Result:** Increased test coverage and confidence in `ConstellationStorage` component's error handling.

---
*PR created automatically by Jules for task [4204372700955716691](https://jules.google.com/task/4204372700955716691) started by @02loveslollipop*