### PR TITLE
🧪 Add test for stego_inspect missing file error

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -49,6 +49,7 @@ jobs:
           python3 -m py_compile scripts/opencrow_reversing_mcp.py
           python3 -m py_compile scripts/opencrow_reversing_worker.py
           python3 -m py_compile scripts/reversing_mcp_smoke.py
+          python3 -m py_compile scripts/stego_mcp_smoke.py
           python3 -m py_compile scripts/opencrow_network_mcp.py
           python3 -m py_compile scripts/opencrow_utility_mcp.py
           python3 -m py_compile scripts/opencrow_stego_mcp.py
@@ -120,6 +121,9 @@ jobs:
 
       - name: Smoke reversing MCP workflows
         run: python3 scripts/reversing_mcp_smoke.py --env ctf
+
+      - name: Smoke stego MCP workflows
+        run: python3 scripts/stego_mcp_smoke.py
 
       - name: Probe first-wave MCP servers
         run: |

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ smoke:
 	python3 -m py_compile scripts/opencrow_reversing_mcp.py
 	python3 -m py_compile scripts/opencrow_reversing_worker.py
 	python3 -m py_compile scripts/reversing_mcp_smoke.py
+	python3 -m py_compile scripts/stego_mcp_smoke.py
 	python3 -m py_compile scripts/opencrow_network_mcp.py
 	python3 -m py_compile scripts/opencrow_utility_mcp.py
 	python3 -m py_compile scripts/opencrow_stego_mcp.py

--- a/scripts/stego_mcp_smoke.py
+++ b/scripts/stego_mcp_smoke.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Smoke test the public OpenCROW stego MCP surface against missing file errors."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import opencrow_stego_mcp as stego_mcp
+
+def main() -> int:
+    server = stego_mcp.build_server()
+    stego_inspect_handler = server.tools["stego_inspect"].handler
+
+    arguments = {"path": "/path/to/nonexistent/file.txt"}
+    result = stego_inspect_handler(arguments)
+
+    if result.get("ok"):
+        print("Test failed: Expected error for missing file, got success.")
+        return 1
+
+    if "Input file does not exist" not in result.get("summary", ""):
+        print(f"Test failed: Expected 'Input file does not exist' in summary, got: {result.get('summary')}")
+        return 1
+
+    if result.get("exit_code") != 2:
+        print(f"Test failed: Expected exit_code 2, got: {result.get('exit_code')}")
+        return 1
+
+    print("Test passed: stego_inspect handles missing files correctly.")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
🎯 **What:** The `stego_inspect` function in `scripts/opencrow_stego_mcp.py` lacked tests for its behavior when passed a path to a non-existent file. This adds a test to ensure it handles this gracefully.
📊 **Coverage:** A new smoke test file `scripts/stego_mcp_smoke.py` was created. It verifies that when `stego_inspect` is called with a dummy path, it returns a proper error envelope with summary "Input file does not exist" and exit code 2. The test is integrated into `Makefile` (`make smoke` checking) and `.github/workflows/smoke.yml`.
✨ **Result:** Missing file behavior is now covered by an automated test.

---
*PR created automatically by Jules for task [2839382722865007541](https://jules.google.com/task/2839382722865007541) started by @02loveslollipop*