### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix timing attack vulnerability in resume_secret verification

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-28 - [Timing Attack Vulnerability in Secret Comparison]
+**Vulnerability:** A standard string equality operator `!=` was used in `constellation/storage.py` to compare cryptographic hash digests (`resume_secret_digest`).
+**Learning:** Comparing sensitive secrets or their digests with standard equality operators is susceptible to timing attacks, as the comparison halts upon finding the first mismatching character. This allows attackers to potentially infer secrets by measuring response times.
+**Prevention:** Always use constant-time comparison functions, like `secrets.compare_digest()` in Python, when validating cryptographic secrets or digests to mitigate timing attacks.

--- a/constellation/storage.py
+++ b/constellation/storage.py
@@ -1053,7 +1053,7 @@ class ConstellationStorage:
             )
 
         expected = current.get("resume_secret_digest")
-        if not isinstance(expected, str) or expected != digest_secret(secret):
+        if not isinstance(expected, str) or not secrets.compare_digest(expected, digest_secret(secret)):
             raise PermissionError("Invalid resume secret for this topic identity.")
 
         updated = self.members.find_one_and_update(


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Used `!=` to compare cryptographic digests, creating a timing attack vector.
🎯 Impact: An attacker could potentially infer the secret digest by measuring comparison timings.
🔧 Fix: Used `secrets.compare_digest` for constant-time comparison.
✅ Verification: Ensure tests pass and the code functions without errors.

---
*PR created automatically by Jules for task [17643927300782785269](https://jules.google.com/task/17643927300782785269) started by @02loveslollipop*