### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secrets in config.py

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Hardcoded Secrets in Config
+**Vulnerability:** Found hardcoded secrets (`opencrow-constellation-ui-dev-secret`) used as default values for `ui_secret_key` and `ui_shared_secret` in `constellation/config.py`.
+**Learning:** Hardcoded default secrets create a severe risk where deployments may use well-known secrets for session encryption and backend authentication if operators forget to set environment variables.
+**Prevention:** Default fallback secrets should be randomly generated at runtime using `secrets.token_hex(32)` (for session keys) or left blank (for optional shared secrets) to force explicit configuration or secure defaults.

--- a/constellation/config.py
+++ b/constellation/config.py
@@ -311,9 +311,9 @@ def load_ui_settings() -> UISettings:
                 "OPENCROW_CONSTELLATION_UI_SECRET_KEY",
                 config,
                 "ui_secret_key",
-                "opencrow-constellation-ui-dev-secret",
+                "",
             )
-        ),
+        ) or secrets.token_hex(32),
         default_display_name=str(
             _env_or_config(
                 "OPENCROW_CONSTELLATION_UI_DISPLAY_NAME",
@@ -327,7 +327,7 @@ def load_ui_settings() -> UISettings:
             "OPENCROW_CONSTELLATION_UI_SHARED_SECRET",
             config,
             "ui_shared_secret",
-            "opencrow-constellation-ui-dev-secret",
+            "",
         ))
         else None,
     )


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `constellation/config.py` file had hardcoded default fallback values (`opencrow-constellation-ui-dev-secret`) for both the Flask session secret (`ui_secret_key`) and the UI-to-backend authentication shared secret (`ui_shared_secret`). If deployments fail to properly set environment variables, they end up using a well-known, weak secret for security-critical configuration.
🎯 Impact: Attackers who know the default secret could decrypt or forge session cookies (leading to authentication bypass) or spoof UI-to-backend requests directly bypassing proper authorization checks.
🔧 Fix: Removed the hardcoded string from both settings. For the `ui_secret_key`, it now correctly falls back to generating a random 32-byte hex token via `secrets.token_hex(32)`. For the `ui_shared_secret`, it correctly defaults to `None`/an empty string if not provided via environment configurations. 
✅ Verification: Ran the `pytest tests/` unit tests to ensure configurations continue to load and backend endpoints still operate as expected.

---
*PR created automatically by Jules for task [15336266676120264109](https://jules.google.com/task/15336266676120264109) started by @02loveslollipop*