### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack vulnerability in token validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-07-23 - Timing Attack Vulnerability in Token Validation
+**Vulnerability:** A timing attack vulnerability was found in the `validate_system_token` method where the `in` operator (which uses early-exit string comparison) was used to check if an input token matches any of the stored `system_tokens`.
+**Learning:** Early-exit string comparisons leak timing information that can theoretically be used to guess the token one character at a time, especially over a network.
+**Prevention:** Always use constant-time comparison functions like `secrets.compare_digest` for validating authentication tokens, passwords, or cryptographic secrets to prevent timing attacks.

--- a/constellation/storage.py
+++ b/constellation/storage.py
@@ -111,7 +111,10 @@ class ConstellationStorage:
         self.agent_events.create_index([("runtime_id", ASCENDING), ("created_at", DESCENDING)])
 
     def validate_system_token(self, token: str) -> bool:
-        return token in self.settings.system_tokens
+        if not token:
+            return False
+        # Use constant-time comparison to prevent timing attacks
+        return any(secrets.compare_digest(token, sys_token) for sys_token in self.settings.system_tokens)
 
     def register_runtime(
         self,


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix timing attack vulnerability

🚨 Severity: HIGH
💡 Vulnerability: The `validate_system_token` method used the `in` operator which performs early-exit string comparison, leaking timing information that could allow an attacker to bypass token authentication.
🎯 Impact: Attackers could theoretically guess the token one character at a time, bypassing security checks and gaining unauthorized access.
🔧 Fix: Used `secrets.compare_digest` for constant-time comparison to prevent timing leaks.
✅ Verification: Ensure the updated `validate_system_token` passes all tests and blocks timing analysis.

---
*PR created automatically by Jules for task [462709182762822141](https://jules.google.com/task/462709182762822141) started by @02loveslollipop*