### PR TITLE
Security: [MEDIUM] Fix timing attack vulnerability on token validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2024-07-23 - Prevent Timing Attacks in Token Validation
+
+**Vulnerability:** Token validation in `constellation/storage.py` used `token in self.settings.system_tokens`, which relies on string equality checking. This could allow an attacker to perform timing attacks to deduce valid tokens byte by byte.
+
+**Learning:** When checking against a set or list of sensitive tokens, using the `in` operator relies on non-constant-time comparisons. Constant-time comparisons must be enforced across all secret validations, even when checking against multiple valid tokens.
+
+**Prevention:** Always use `secrets.compare_digest` for validating tokens, secrets, or passwords. When matching against a list, use a generator expression like `any(secrets.compare_digest(token, system_token) for system_token in system_tokens)` to check all valid tokens safely.

--- a/constellation/storage.py
+++ b/constellation/storage.py
@@ -111,7 +111,9 @@ class ConstellationStorage:
         self.agent_events.create_index([("runtime_id", ASCENDING), ("created_at", DESCENDING)])
 
     def validate_system_token(self, token: str) -> bool:
-        return token in self.settings.system_tokens
+        if not token:
+            return False
+        return any(secrets.compare_digest(token, system_token) for system_token in self.settings.system_tokens)
 
     def register_runtime(
         self,


### PR DESCRIPTION
## Summary 
 
Fixed a potential timing attack vulnerability in system token validation by using constant-time string comparison.
 
## Severity 
 
MEDIUM
 
## Affected Component 
 
System token validation in `constellation/storage.py`
 
## Security Issue 
 
The `validate_system_token` method verified tokens using the `in` operator against a tuple of valid tokens. The `in` operator relies on standard string equality checks, which fail fast as soon as a character mismatch is found. This potentially allows an attacker to perform timing attacks to discover valid system tokens byte by byte.
 
## Impact 
 
If exploited, an attacker could theoretically discover a valid system token, granting them administrative access to constellation runtimes and endpoints.
 
## Resolution 
 
Modified the token validation logic to iterate over the valid system tokens and use `secrets.compare_digest` to perform a constant-time comparison against each.
 
## Verification 
 
- [x] Targeted tests 
- [x] Relevant test suite 
- [x] Manual or regression verification 
 
(Note: `make smoke` fails on Miniconda prerequisite which is unavailable, but python unit tests in the suite passed).
 
## Scope 
 
The patch is intentionally small to resolve only the insecure token comparison check.
 
## Duplicate Check 
 
Confirmed that no currently open pull request addresses the same vulnerability, root cause, dependency, affected component, or code path.

---
*PR created automatically by Jules for task [10366018111204863868](https://jules.google.com/task/10366018111204863868) started by @02loveslollipop*