### PR TITLE
Sentinel: [HIGH] Fix timing attack in validate_system_token

### DIFF
--- a/constellation/storage.py
+++ b/constellation/storage.py
@@ -111,7 +111,12 @@ class ConstellationStorage:
         self.agent_events.create_index([("runtime_id", ASCENDING), ("created_at", DESCENDING)])
 
     def validate_system_token(self, token: str) -> bool:
-        return token in self.settings.system_tokens
+        if not token:
+            return False
+        for system_token in self.settings.system_tokens:
+            if secrets.compare_digest(token, system_token):
+                return True
+        return False
 
     def register_runtime(
         self,


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `validate_system_token` method inside `constellation/storage.py` used the `in` operator (a simple equality check under the hood) against a sequence to validate sensitive system tokens. This standard comparison is vulnerable to timing attacks, allowing an attacker to deduce the token byte-by-byte by observing the time taken to reject an invalid token.
🎯 **Impact:** If exploited, an attacker could forge a valid system token, granting them unauthorized administrative access to the runtime environments and the underlying platform.
🔧 **Fix:** Refactored `validate_system_token` to use Python's constant-time comparison function, `secrets.compare_digest`, which mitigates timing side channels. Additionally, implemented an early exit check for empty/`None` tokens to prevent `TypeError` exceptions during execution.
✅ **Verification:** Ran the full test suite (`pytest tests/ scripts/test_*.py`) which passed successfully. Confirmed `secrets` module is correctly imported to prevent `NameError`.

---
*PR created automatically by Jules for task [6522348851020723542](https://jules.google.com/task/6522348851020723542) started by @02loveslollipop*