### PR TITLE
Security: [HIGH] Fix timing attack vulnerability in token validation

### DIFF
--- a/constellation/storage.py
+++ b/constellation/storage.py
@@ -111,7 +111,9 @@ class ConstellationStorage:
         self.agent_events.create_index([("runtime_id", ASCENDING), ("created_at", DESCENDING)])
 
     def validate_system_token(self, token: str) -> bool:
-        return token in self.settings.system_tokens
+        if not token:
+            return False
+        return any(secrets.compare_digest(token, expected) for expected in self.settings.system_tokens)
 
     def register_runtime(
         self,
@@ -1053,7 +1055,7 @@ class ConstellationStorage:
             )
 
         expected = current.get("resume_secret_digest")
-        if not isinstance(expected, str) or expected != digest_secret(secret):
+        if not isinstance(expected, str) or not secrets.compare_digest(expected, digest_secret(secret)):
             raise PermissionError("Invalid resume secret for this topic identity.")
 
         updated = self.members.find_one_and_update(


### PR DESCRIPTION
## Summary
Replace simple string comparisons (`in` and `!=`) with constant-time comparisons (`secrets.compare_digest`) for token and secret validation. This mitigates potential timing attacks when verifying system tokens and member resume secrets.

## Severity
HIGH

## Affected Component
`constellation/storage.py` (specifically `validate_system_token` and `resume_member` methods)

## Security Issue
Authentication token and secret verification used non-constant time comparison operations (e.g. string equality or `in`), which fail early upon encountering the first incorrect character.

## Impact
An attacker could theoretically measure the time taken to validate tokens or secrets, and use this timing side channel to guess valid secrets character by character, leading to authentication bypass.

## Resolution
Used `secrets.compare_digest` to perform constant-time comparisons, eliminating the timing side-channel. Also added a null-check to `validate_system_token` to prevent TypeErrors before `compare_digest` is called.

## Verification
- [x] Relevant test suite (`PYTHONPATH=scripts:. python3 -m pytest tests/ scripts/test_*.py`)
- [ ] Manual or regression verification

## Scope
The patch is intentionally small and focused to specifically address the timing vulnerability at its root cause without affecting broader functionality.

## Duplicate Check
Confirmed that no currently open pull request addresses the same vulnerability, root cause, dependency, affected component, or code path.

---
*PR created automatically by Jules for task [7770901710988225904](https://jules.google.com/task/7770901710988225904) started by @02loveslollipop*