### PR TITLE
Security: [MEDIUM] Fix timing attack vulnerability in token validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2025-02-14 - Fix timing attack vulnerability in token validation
+
+**Vulnerability:** The `validate_system_token` method in `constellation/storage.py` used a simple `in` check (`token in self.settings.system_tokens`) to validate system tokens, which is susceptible to timing attacks.
+
+**Learning:** Python's `in` operator (and `==` operator for strings) performs character-by-character comparison and returns early on the first mismatch. This allows an attacker to deduce the token length and content by measuring the time it takes for the server to reject incorrect tokens.
+
+**Prevention:** Always use constant-time comparison functions like `secrets.compare_digest` when verifying security tokens, passwords, or hashes.

--- a/constellation/storage.py
+++ b/constellation/storage.py
@@ -111,7 +111,9 @@ class ConstellationStorage:
         self.agent_events.create_index([("runtime_id", ASCENDING), ("created_at", DESCENDING)])
 
     def validate_system_token(self, token: str) -> bool:
-        return token in self.settings.system_tokens
+        if not token:
+            return False
+        return any(secrets.compare_digest(token, system_token) for system_token in self.settings.system_tokens)
 
     def register_runtime(
         self,


### PR DESCRIPTION
## Summary

Updated `validate_system_token` in `constellation/storage.py` to use `secrets.compare_digest` instead of a simple `in` check to prevent timing attacks during token validation.

## Severity

MEDIUM

## Affected Component

`validate_system_token` method in `constellation/storage.py`

## Security Issue

The previous implementation used Python's `in` operator to check if a given token was present in the list of valid system tokens. The `in` operator (and string equality) performs character-by-character comparison and returns early on the first mismatch. This allows an attacker to deduce the token length and content by measuring the time it takes for the server to reject incorrect tokens (timing attack).

## Impact

An attacker could potentially bypass authentication by deducing a valid system token character by character through timing attacks.

## Resolution

Replaced the `in` check with a loop that uses `secrets.compare_digest()` to perform a constant-time comparison against each valid system token. Also added an initial truthiness check (`if not token:`) to prevent processing empty tokens.

## Verification

- [x] Relevant test suite (`python3 -m pytest tests/`)
- [ ] Lint
- [ ] Formatting
- [ ] Type checking
- [ ] Build
- [ ] Manual or regression verification

## Scope

The patch is intentionally small and focused, only modifying the single `validate_system_token` method to address this specific security weakness.

## Duplicate Check

Confirmed that no currently open pull request addresses the same vulnerability, root cause, dependency, affected component, or code path.

---
*PR created automatically by Jules for task [3071854946140830818](https://jules.google.com/task/3071854946140830818) started by @02loveslollipop*