### PR TITLE
Security: [MEDIUM] Fix timing attack on Constellation System Token Validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-28 - Security: Prevent timing attacks on system token validation
+**Vulnerability:** The system token validation in `constellation/storage.py` used a non-constant time string matching (`in` operation on `self.settings.system_tokens`).
+**Learning:** String comparisons like `in` and `==` short-circuit on the first mismatch, allowing an attacker to iteratively guess a valid token character by character based on varying response times.
+**Prevention:** Always use `secrets.compare_digest` for validating tokens and secrets to ensure comparisons occur in constant time.

--- a/constellation/storage.py
+++ b/constellation/storage.py
@@ -111,7 +111,9 @@ class ConstellationStorage:
         self.agent_events.create_index([("runtime_id", ASCENDING), ("created_at", DESCENDING)])
 
     def validate_system_token(self, token: str) -> bool:
-        return token in self.settings.system_tokens
+        if not token:
+            return False
+        return any(secrets.compare_digest(token, system_token) for system_token in self.settings.system_tokens)
 
     def register_runtime(
         self,


### PR DESCRIPTION
## Summary
Updated `validate_system_token` in `constellation/storage.py` to use `secrets.compare_digest` to perform constant-time string comparisons.

## Severity
MEDIUM

## Affected Component
Constellation Backend Storage (System Token Validation)

## Security Issue
Timing attack vulnerability. The simple `in` string membership check short-circuits upon encountering the first mismatched character. Attackers could potentially guess a valid system token one character at a time by analyzing variations in response times.

## Impact
If successfully exploited, an attacker could recover a valid system token, granting unauthorized access to the constellation system backend.

## Resolution
Modified `validate_system_token` to check each token using `secrets.compare_digest` to guarantee constant-time execution. An initial truthy check prevents issues with `None` values.

## Verification
- Run `PYTHONPATH=scripts:. python3 -m pytest tests/ scripts/test_*.py`
- All tests (specifically `tests/test_storage.py`) execute completely.

## Scope
`constellation/storage.py`

## Duplicate Check
Checked open PRs and the issue tracker; no existing work covers this specific fix.

---
*PR created automatically by Jules for task [3736473981651378619](https://jules.google.com/task/3736473981651378619) started by @02loveslollipop*