### PR TITLE
Security: [MEDIUM] Fix timing attack vulnerabilities on ConstellationStorage

### DIFF
--- a/constellation/storage.py
+++ b/constellation/storage.py
@@ -111,7 +111,12 @@ class ConstellationStorage:
         self.agent_events.create_index([("runtime_id", ASCENDING), ("created_at", DESCENDING)])
 
     def validate_system_token(self, token: str) -> bool:
-        return token in self.settings.system_tokens
+        if not token:
+            return False
+        for expected in self.settings.system_tokens:
+            if secrets.compare_digest(token, expected):
+                return True
+        return False
 
     def register_runtime(
         self,
@@ -1053,7 +1058,7 @@ class ConstellationStorage:
             )
 
         expected = current.get("resume_secret_digest")
-        if not isinstance(expected, str) or expected != digest_secret(secret):
+        if not isinstance(expected, str) or not secret or not secrets.compare_digest(expected, digest_secret(secret)):
             raise PermissionError("Invalid resume secret for this topic identity.")
 
         updated = self.members.find_one_and_update(


### PR DESCRIPTION
## Summary
Replaced standard string equality operators with `secrets.compare_digest` for token verification in `constellation/storage.py` to prevent timing attacks.

## Severity
MEDIUM

## Affected Component
ConstellationStorage component (`constellation/storage.py`), specifically `validate_system_token` and `resume_member` methods.

## Security Issue
Timing attacks could allow an attacker to deduce tokens character-by-character based on the application's response time when verifying secrets using standard `==` or `in` operations, as these operations return early upon encountering a mismatch.

## Impact
If successfully exploited, an attacker could incrementally guess a system token or resume secret, potentially gaining unauthorized administrative access or taking over user sessions on a topic.

## Resolution
Used `secrets.compare_digest` for constant-time comparison when verifying tokens and secrets, ensuring that the time taken is independent of the input string, effectively eliminating the timing attack vector. Input validation ensures that `None` or empty strings are safely handled without raising a `TypeError`.

## Verification
- Verified code changes prevent early exits during token comparison.
- `make smoke` and `pytest tests/ scripts/test_*.py` tests successfully pass, validating functionality remains correct.

## Scope
`constellation/storage.py`

## Duplicate Check
Verified no existing open pull requests address this issue.

---
*PR created automatically by Jules for task [1205215323302434486](https://jules.google.com/task/1205215323302434486) started by @02loveslollipop*