### PR TITLE
fix(ci): grant contents:write permission to deploy-release workflow

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -7,6 +7,9 @@ on:
       - "v*.*.*"
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build-and-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Grants write permissions to GITHUB_TOKEN so softprops/action-gh-release can upload release assets.