### PR TITLE
chore: update gitignore for NEXT_STEP.md and dist-pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@ __pycache__/
 .opencrow-constellation/
 constellation/private/
 dist/
+dist-pages/
 .pytest_cache/
 .vscode/
 .agents/
 .jules/
+NEXT_STEP.md


### PR DESCRIPTION
Updates .gitignore to include NEXT_STEP.md and dist-pages build artifacts.