### PR TITLE
feat(pages): serve CLI installer at opencrow.02labs.me/releases/cli.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ OpenCROW is distributed via GitHub Releases. End users do not need to clone the 
 To install the OpenCROW CLI, run the single-command remote installer:
 
 ```bash
-curl -fsSL https://opencrow.02labs.me/release/opencrow-cli.sh | bash
+curl -fsSL https://opencrow.02labs.me/releases/cli.sh | bash
 ```
 
 To install a specific version release:
 
 ```bash
-curl -fsSL https://opencrow.02labs.me/release/opencrow-cli.sh | bash -s -- --version v1.0.0
+curl -fsSL https://opencrow.02labs.me/releases/cli.sh | bash -s -- --version v1.0.0
 ```
 
 ### 2. Deploying OpenCROW Constellation (Docker)

--- a/dist-pages/opencrow-cli.sh
+++ b/dist-pages/opencrow-cli.sh
@@ -13,7 +13,7 @@ usage() {
 OpenCROW Remote Installer
 
 Usage:
-  curl -fsSL https://opencrow.02labs.me/release/opencrow-cli.sh | bash -s -- [options]
+  curl -fsSL https://opencrow.02labs.me/releases/cli.sh | bash -s -- [options]
 
 Options:
   --version <tag>   Specify GitHub Release version tag (default: latest release)

--- a/dist-pages/opencrow.sh
+++ b/dist-pages/opencrow.sh
@@ -13,7 +13,7 @@ usage() {
 OpenCROW Remote Installer
 
 Usage:
-  curl -fsSL https://opencrow.02labs.me/release/opencrow-cli.sh | bash -s -- [options]
+  curl -fsSL https://opencrow.02labs.me/releases/cli.sh | bash -s -- [options]
 
 Options:
   --version <tag>   Specify GitHub Release version tag (default: latest release)

--- a/dist-pages/release/opencrow-cli.sh
+++ b/dist-pages/release/opencrow-cli.sh
@@ -13,7 +13,7 @@ usage() {
 OpenCROW Remote Installer
 
 Usage:
-  curl -fsSL https://opencrow.02labs.me/release/opencrow-cli.sh | bash -s -- [options]
+  curl -fsSL https://opencrow.02labs.me/releases/cli.sh | bash -s -- [options]
 
 Options:
   --version <tag>   Specify GitHub Release version tag (default: latest release)

--- a/scripts/build_releases.py
+++ b/scripts/build_releases.py
@@ -59,12 +59,16 @@ def main() -> None:
     pages_dir = ROOT_DIR / "dist-pages"
     if pages_dir.exists():
         shutil.rmtree(pages_dir)
+    (pages_dir / "releases").mkdir(parents=True, exist_ok=True)
     (pages_dir / "release").mkdir(parents=True, exist_ok=True)
 
     opencrow_sh_source = ROOT_DIR / "scripts" / "opencrow.sh"
+    shutil.copy2(opencrow_sh_source, pages_dir / "releases" / "cli.sh")
+    shutil.copy2(opencrow_sh_source, pages_dir / "releases" / "opencrow-cli.sh")
     shutil.copy2(opencrow_sh_source, pages_dir / "release" / "opencrow-cli.sh")
     shutil.copy2(opencrow_sh_source, pages_dir / "opencrow-cli.sh")
     shutil.copy2(opencrow_sh_source, pages_dir / "opencrow.sh")
+    shutil.copy2(opencrow_sh_source, pages_dir / "cli.sh")
 
     # Cloudflare Pages _redirects file for root URL redirect
     redirects_content = "/ https://github.com/02loveslollipop/OpenCROW 302\n"

--- a/scripts/opencrow.sh
+++ b/scripts/opencrow.sh
@@ -13,7 +13,7 @@ usage() {
 OpenCROW Remote Installer
 
 Usage:
-  curl -fsSL https://opencrow.02labs.me/release/opencrow-cli.sh | bash -s -- [options]
+  curl -fsSL https://opencrow.02labs.me/releases/cli.sh | bash -s -- [options]
 
 Options:
   --version <tag>   Specify GitHub Release version tag (default: latest release)


### PR DESCRIPTION
Updates Cloudflare Pages static site assets and documentation to serve the OpenCROW CLI installer at opencrow.02labs.me/releases/cli.sh.