### PR TITLE
ci: move workflows to Node 24 actions

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -24,11 +24,11 @@ jobs:
       PORTABLE_ARM64_URL: ${{ vars.PORTABLE_PYTHON_ARM64_URL }}
       PORTABLE_ARM64_SHA256: ${{ vars.PORTABLE_PYTHON_ARM64_SHA256 }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -106,7 +106,7 @@ jobs:
         run: gh release edit "$GITHUB_REF_NAME" --draft=false --latest
 
       - name: Advance Cloudflare stable installer pointers
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/pr-verification.yml
+++ b/.github/workflows/pr-verification.yml
@@ -11,14 +11,14 @@ jobs:
   tests-and-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - run: python -m pip install --upgrade pip pytest -r services/constellation/requirements-runtime.txt
       - run: make test
       - run: make smoke
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: .cache/docs-external-links.json
           key: docs-external-${{ hashFiles('**/*.md') }}
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ matrix.image }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Exercise dependency-free selector and architecture path
         env:
           OPENCROW_TEST_MACHINE: ${{ matrix.arch }}

--- a/.github/workflows/provider-compatibility.yml
+++ b/.github/workflows/provider-compatibility.yml
@@ -14,11 +14,12 @@ jobs:
     env:
       PROVIDER_SMOKE_ENABLED: ${{ secrets.OPENCROW_PROVIDER_SMOKE_ENABLED }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
-      - uses: actions/setup-python@v5
+          package-manager-cache: false
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - run: python -m pip install --upgrade pytest -r services/constellation/requirements-runtime.txt

--- a/.github/workflows/system-install-matrix.yml
+++ b/.github/workflows/system-install-matrix.yml
@@ -16,7 +16,7 @@ jobs:
         image: ["ubuntu:24.04", "fedora:42", "archlinux:latest"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Test actual full and skills-only installation
         run: >-
           docker run --rm

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,8 +12,8 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - run: python -m pip install --upgrade pip pytest -r services/constellation/requirements.txt


### PR DESCRIPTION
Updates GitHub-maintained actions to their current Node 24 majors and upgrades the Cloudflare release action to v4. This removes the Node 20 deprecation warnings observed during the main verification workflows. Automatic npm caching is explicitly disabled in the provider smoke job.