### PR TITLE
fix: publish stable pointers to Cloudflare production

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -119,4 +119,30 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist-pages --project-name opencrow --branch release
+          # The opencrow Pages project's production branch is main. The files
+          # are still built from and validated against the stable release tag.
+          command: pages deploy dist-pages --project-name opencrow --branch main
+
+      - name: Verify public stable installer pointers
+        shell: bash
+        run: |
+          set -euo pipefail
+          verify_pointer() {
+            local name="$1"
+            local downloaded="$RUNNER_TEMP/opencrow-live-$name"
+            local attempt
+            for attempt in {1..12}; do
+              if curl -fsSL \
+                "https://opencrow.02labs.me/$name?release=$GITHUB_REF_NAME&attempt=$attempt" \
+                -o "$downloaded" && cmp -s "dist-pages/$name" "$downloaded"; then
+                return 0
+              fi
+              sleep 5
+            done
+            echo "::error file=$name::Cloudflare stable pointer does not match the tagged release" >&2
+            return 1
+          }
+
+          for name in install.sh skills.sh release-manifest.json release-checksums.txt; do
+            verify_pointer "$name"
+          done

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -85,3 +85,10 @@ def test_release_workflow_scopes_dedicated_wiki_ssh_credential() -> None:
     assert "WIKI_DEPLOY_TOKEN" not in workflow
     assert "git@github.com:02loveslollipop/OpenCROW.wiki.git" in workflow
     assert "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqq" in workflow
+
+
+def test_release_workflow_deploys_and_verifies_production_installer_pointers() -> None:
+    workflow = (ROOT / ".github/workflows/deploy-release.yml").read_text(encoding="utf-8")
+    assert "pages deploy dist-pages --project-name opencrow --branch main" in workflow
+    assert "https://opencrow.02labs.me/$name?release=$GITHUB_REF_NAME" in workflow
+    assert 'cmp -s "dist-pages/$name" "$downloaded"' in workflow


### PR DESCRIPTION
## Summary
- deploy the tagged stable pointer bundle to the Pages production branch
- verify public custom-domain files byte-for-byte after deployment
- add regression coverage for the release workflow

## Verification
- `make test` (118 passed)
- workflow YAML parses successfully
- current preview deployment already matches the 2.0.0 release assets; this fix promotes that content to production