### PR TITLE
release: Cloudflare production pointer hotfix

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -119,4 +119,30 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist-pages --project-name opencrow --branch release
+          # The opencrow Pages project's production branch is main. The files
+          # are still built from and validated against the stable release tag.
+          command: pages deploy dist-pages --project-name opencrow --branch main
+
+      - name: Verify public stable installer pointers
+        shell: bash
+        run: |
+          set -euo pipefail
+          verify_pointer() {
+            local name="$1"
+            local downloaded="$RUNNER_TEMP/opencrow-live-$name"
+            local attempt
+            for attempt in {1..12}; do
+              if curl -fsSL \
+                "https://opencrow.02labs.me/$name?release=$GITHUB_REF_NAME&attempt=$attempt" \
+                -o "$downloaded" && cmp -s "dist-pages/$name" "$downloaded"; then
+                return 0
+              fi
+              sleep 5
+            done
+            echo "::error file=$name::Cloudflare stable pointer does not match the tagged release" >&2
+            return 1
+          }
+
+          for name in install.sh skills.sh release-manifest.json release-checksums.txt; do
+            verify_pointer "$name"
+          done

--- a/installer/manifests/release.json
+++ b/installer/manifests/release.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "channel": "stable",
   "supported": {
     "os": ["linux"],

--- a/installer/opencrow_manager.py
+++ b/installer/opencrow_manager.py
@@ -28,7 +28,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Iterable
 
 
-VERSION = "2.0.0"
+VERSION = "2.0.1"
 PROVIDERS = ("codex", "opencode", "claude", "antigravity")
 COMMANDS = {"codex": "codex", "opencode": "opencode", "claude": "claude", "antigravity": "agy"}
 SKILLS_DIRS = {

--- a/packages/lifecycle/opencrow_lifecycle/__init__.py
+++ b/packages/lifecycle/opencrow_lifecycle/__init__.py
@@ -8,4 +8,4 @@ from .engine import (
 )
 
 __all__ = ["CANONICAL_DOCUMENTS", "LifecycleError", "WorkflowEngine", "find_workspace"]
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/packages/lifecycle/opencrow_lifecycle/mcp_server.py
+++ b/packages/lifecycle/opencrow_lifecycle/mcp_server.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 from typing import Any, Callable
 
+from . import __version__
 from .engine import CANONICAL_DOCUMENTS, LifecycleError, WorkflowEngine
 
 
@@ -159,7 +160,7 @@ class StdioServer:
                 result: JSON = {
                     "protocolVersion": self.protocol,
                     "capabilities": {"tools": {"listChanged": False}},
-                    "serverInfo": {"name": "opencrow-lifecycle-mcp", "version": "2.0.0"},
+                    "serverInfo": {"name": "opencrow-lifecycle-mcp", "version": __version__},
                 }
             elif method == "ping":
                 result = {}

--- a/scripts/build_releases.py
+++ b/scripts/build_releases.py
@@ -140,7 +140,7 @@ def portable_python(source: Path | None, destination: Path, architecture: str, a
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--version", default="2.0.0")
+    parser.add_argument("--version", default="2.0.1")
     parser.add_argument("--release-tag")
     parser.add_argument("--source-sha")
     parser.add_argument("--portable-python-x86", type=Path)

--- a/scripts/generate_wiki.py
+++ b/scripts/generate_wiki.py
@@ -120,7 +120,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     parser.add_argument("--output", type=Path, default=ROOT / "dist" / "wiki")
-    parser.add_argument("--version", default="2.0.0")
+    parser.add_argument("--version", default="2.0.1")
     parser.add_argument("--release-tag")
     parser.add_argument("--source-sha")
     return parser.parse_args()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from installer import opencrow_manager
+from opencrow_lifecycle import __version__
+from opencrow_lifecycle.mcp_server import StdioServer
+from scripts import build_releases, generate_wiki
+
+
+def test_release_version_is_consistent(monkeypatch) -> None:
+    manifest = json.loads((ROOT / "installer/manifests/release.json").read_text(encoding="utf-8"))
+    expected = manifest["version"]
+
+    monkeypatch.setattr(sys, "argv", ["build_releases.py"])
+    build_version = build_releases.parse_args().version
+    monkeypatch.setattr(sys, "argv", ["generate_wiki.py"])
+    wiki_version = generate_wiki.parse_args().version
+
+    response = StdioServer(ROOT).dispatch({"id": 1, "method": "initialize", "params": {}})
+    assert response is not None
+    mcp_version = response["result"]["serverInfo"]["version"]
+
+    assert expected == "2.0.1"
+    assert {opencrow_manager.VERSION, __version__, mcp_version, build_version, wiki_version} == {expected}

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -85,3 +85,10 @@ def test_release_workflow_scopes_dedicated_wiki_ssh_credential() -> None:
     assert "WIKI_DEPLOY_TOKEN" not in workflow
     assert "git@github.com:02loveslollipop/OpenCROW.wiki.git" in workflow
     assert "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqq" in workflow
+
+
+def test_release_workflow_deploys_and_verifies_production_installer_pointers() -> None:
+    workflow = (ROOT / ".github/workflows/deploy-release.yml").read_text(encoding="utf-8")
+    assert "pages deploy dist-pages --project-name opencrow --branch main" in workflow
+    assert "https://opencrow.02labs.me/$name?release=$GITHUB_REF_NAME" in workflow
+    assert 'cmp -s "dist-pages/$name" "$downloaded"' in workflow


### PR DESCRIPTION
Promotes the Cloudflare production deployment correction to `release`.

Validated in PRs #78 and #79 with all checks passing. After merge, a patch tag will execute the complete stable transaction and assert that the public custom-domain files exactly match the tagged artifacts.