### PR TITLE
promote: OpenCROW 2.0.1 version alignment

### DIFF
--- a/installer/manifests/release.json
+++ b/installer/manifests/release.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "channel": "stable",
   "supported": {
     "os": ["linux"],

--- a/installer/opencrow_manager.py
+++ b/installer/opencrow_manager.py
@@ -28,7 +28,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Iterable
 
 
-VERSION = "2.0.0"
+VERSION = "2.0.1"
 PROVIDERS = ("codex", "opencode", "claude", "antigravity")
 COMMANDS = {"codex": "codex", "opencode": "opencode", "claude": "claude", "antigravity": "agy"}
 SKILLS_DIRS = {

--- a/packages/lifecycle/opencrow_lifecycle/__init__.py
+++ b/packages/lifecycle/opencrow_lifecycle/__init__.py
@@ -8,4 +8,4 @@ from .engine import (
 )
 
 __all__ = ["CANONICAL_DOCUMENTS", "LifecycleError", "WorkflowEngine", "find_workspace"]
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/packages/lifecycle/opencrow_lifecycle/mcp_server.py
+++ b/packages/lifecycle/opencrow_lifecycle/mcp_server.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 from typing import Any, Callable
 
+from . import __version__
 from .engine import CANONICAL_DOCUMENTS, LifecycleError, WorkflowEngine
 
 
@@ -159,7 +160,7 @@ class StdioServer:
                 result: JSON = {
                     "protocolVersion": self.protocol,
                     "capabilities": {"tools": {"listChanged": False}},
-                    "serverInfo": {"name": "opencrow-lifecycle-mcp", "version": "2.0.0"},
+                    "serverInfo": {"name": "opencrow-lifecycle-mcp", "version": __version__},
                 }
             elif method == "ping":
                 result = {}

--- a/scripts/build_releases.py
+++ b/scripts/build_releases.py
@@ -140,7 +140,7 @@ def portable_python(source: Path | None, destination: Path, architecture: str, a
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--version", default="2.0.0")
+    parser.add_argument("--version", default="2.0.1")
     parser.add_argument("--release-tag")
     parser.add_argument("--source-sha")
     parser.add_argument("--portable-python-x86", type=Path)

--- a/scripts/generate_wiki.py
+++ b/scripts/generate_wiki.py
@@ -120,7 +120,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     parser.add_argument("--output", type=Path, default=ROOT / "dist" / "wiki")
-    parser.add_argument("--version", default="2.0.0")
+    parser.add_argument("--version", default="2.0.1")
     parser.add_argument("--release-tag")
     parser.add_argument("--source-sha")
     return parser.parse_args()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from installer import opencrow_manager
+from opencrow_lifecycle import __version__
+from opencrow_lifecycle.mcp_server import StdioServer
+from scripts import build_releases, generate_wiki
+
+
+def test_release_version_is_consistent(monkeypatch) -> None:
+    manifest = json.loads((ROOT / "installer/manifests/release.json").read_text(encoding="utf-8"))
+    expected = manifest["version"]
+
+    monkeypatch.setattr(sys, "argv", ["build_releases.py"])
+    build_version = build_releases.parse_args().version
+    monkeypatch.setattr(sys, "argv", ["generate_wiki.py"])
+    wiki_version = generate_wiki.parse_args().version
+
+    response = StdioServer(ROOT).dispatch({"id": 1, "method": "initialize", "params": {}})
+    assert response is not None
+    mcp_version = response["result"]["serverInfo"]["version"]
+
+    assert expected == "2.0.1"
+    assert {opencrow_manager.VERSION, __version__, mcp_version, build_version, wiki_version} == {expected}


### PR DESCRIPTION
Promotes the 2.0.1 version alignment and consistency regression coverage from `dev` to `main`.

PR #81 passed all six required checks; local test suite reports 119 passed.