### PR TITLE
Security: [HIGH] Fix overly permissive CORS configuration on RuntimeControlWebSocket

### DIFF
--- a/services/constellation/constellation/backend.py
+++ b/services/constellation/constellation/backend.py
@@ -750,7 +750,15 @@ class RuntimeControlWebSocket(tornado.websocket.WebSocketHandler):
         self.runtime_id = ""
 
     def check_origin(self, origin: str) -> bool:
-        return True
+        header = self.request.headers.get("Authorization", "").strip()
+        if header.lower().startswith("bearer "):
+            return True
+        if not origin:
+            return True
+        allowed = self.app_state.settings.allowed_ws_origins
+        if not allowed:
+            return False
+        return _normalize_origin(origin) in allowed
 
     def select_subprotocol(self, subprotocols: list[str]) -> str | None:
         if "opencrow.runtime.v2" in subprotocols:


### PR DESCRIPTION
## Summary
Updates `RuntimeControlWebSocket.check_origin` in the Constellation backend to enforce proper origin validation for WebSocket connections, rather than unconditionally returning `True`.

## Severity
HIGH

## Affected Component
`services/constellation/constellation/backend.py` (Tornado WebSocket Handler)

## Security Issue
The `RuntimeControlWebSocket` handler was exposing a Cross-Site WebSocket Hijacking (CSWSH) vulnerability by explicitly allowing all origins (returning `True` unconditionally in `check_origin`), effectively bypassing Tornado's built-in Same-Origin protections.

## Impact
If an attacker could trick a user with a valid session/token into visiting a malicious site, the attacker's site could potentially establish a WebSocket connection to the Constellation backend on behalf of the user, leading to unauthorized actions or data exfiltration.

## Resolution
Modified `RuntimeControlWebSocket.check_origin` to match the secure implementation in `ConstellationWebSocket`, which validates the origin against an allowed list (`allowed_ws_origins`) and handles explicit Authorization headers.

## Verification
Tests were run via `PYTHONPATH=scripts:services/constellation python3 -m pytest tests/ services/constellation/tests/` and `make smoke`. All passed successfully without any regression.

## Scope
Limited strictly to the single WebSocket handler missing proper origin checks.

## Duplicate Check
Checked open PRs and issue tracker; no existing PRs address this specific CSWSH vulnerability in `RuntimeControlWebSocket`.

---
*PR created automatically by Jules for task [17898032935880078887](https://jules.google.com/task/17898032935880078887) started by @02loveslollipop*